### PR TITLE
setup app.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+  - "3.8"
+
+script:
+  - flake8
+
+install:
+  - pip install pipenv
+  - pipenv install --dev

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+flake8 = "*"
+
+[packages]
+Flask = "~=1.1.2"
+gunicorn = "~=20.0.4"
+
+[requires]
+python_version = "3.8"

--- a/app.py
+++ b/app.py
@@ -1,0 +1,12 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/ping")
+def ping():
+    return "Application is running! Ping worked!"
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
This is the first edition of new code in this repo. This PR sets up the minimum of `.travis.yml`, a brand new `Pipfile` to start with and running the `app.py`.
In order to test the app.py changes, run:
 ```python
python3 app.py """To start the server"""
curl http://127.0.0.1:5000/ping """To call /ping endpoint"""
```