### PR TITLE
ROS-20 Add .env.example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Afterwards you can activate the virtual environment by running:
 pipenv shell
 ```
 
+A list of configurable environment variables is present inside `.env.example` file.
+
 ## Initialize the database
 Run the following commands to excute the db migration scripts.
 ```bash

--- a/ros/.env.example
+++ b/ros/.env.example
@@ -1,0 +1,11 @@
+ROS_DB_USER="postgres"
+ROS_DB_PASS="postgres"
+ROS_DB_HOST="localhost"
+ROS_DB_PORT="15432"
+ROS_DB_NAME="postgres"
+
+INVENTORY_HOST="localhost"
+INVENTORY_PORT="8081"
+
+INSIGHTS_KAFKA_HOST="localhost"
+INSIGHTS_KAFKA_PORT="29092"


### PR DESCRIPTION
This PR adds a `.env.example` file for those users who wish to modify their ROS configurations. They can copy this template to a file called `.env` and ros-backend will start with these configs set.