### PR TITLE
Fix KeyError for performance_score

### DIFF
--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -22,11 +22,10 @@ class PerformanceProfile(db.Model):
 
     @property
     def display_performance_score(self):
-        display_performance_score = {
-            'memory_score': self.performance_score['memory_score'] // 20,
-            'cpu_score': self.performance_score['cpu_score'] // 20,
-            'io_score': self.performance_score['io_score'] // 20
-        }
+        display_performance_score = {}
+        for key, value in self.performance_score.items():
+            display_performance_score[key] = value // 20
+
         return display_performance_score
 
 


### PR DESCRIPTION
PR fixes below bug - 

```
[2021-03-09 10:18:37,018] ERROR in app: Exception on /api/ros/v0/systems [GET]
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/app-root/lib64/python3.8/site-packages/flask_restful/__init__.py", line 468, in wrapper
    resp = resource(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/flask_restful/__init__.py", line 583, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/flask_restful/__init__.py", line 675, in wrapper
    resp = f(*args, **kwargs)
  File "/opt/app-root/src/ros/api/v0/hosts.py", line 98, in get
    host['display_performance_score'] = row.PerformanceProfile.display_performance_score
  File "/opt/app-root/src/ros/lib/models.py", line 28, in display_performance_score
    'io_score': self.performance_score['io_score'] // 20
KeyError: 'io_score'
```