### PR TITLE
RHIROS-85 Modify fields in Hosts and Details API responses

### DIFF
--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -30,10 +30,9 @@ class HostsApi(Resource):
         'state': fields.String,
         'display_performance_score': fields.Nested(display_performance_score_fields),
         'cloud_provider': fields.String,
-        'instance_type': fields.String
-        # TODO - idling_time, io_wait
-        # 'idling_time': fields.String,
-        # 'io_wait': fields.String
+        'instance_type': fields.String,
+        'idling_time': fields.String,
+        'io_wait': fields.String
     }
     meta_fields = {
         'count': fields.Integer,
@@ -113,6 +112,8 @@ class HostsApi(Resource):
                 continue
             host['account'] = row.RhAccount.account
             host['display_performance_score'] = row.PerformanceProfile.display_performance_score
+            host['idling_time'] = row.PerformanceProfile.idling_time
+            host['io_wait'] = row.PerformanceProfile.io_wait
             hosts.append(host)
 
         return build_paginated_system_list_response(
@@ -156,7 +157,6 @@ class HostsApi(Resource):
 class HostDetailsApi(Resource):
     profile_fields = {
         'host_id': fields.String(attribute='inventory_id'),
-        'performance_record': fields.String,
         'rating': fields.Integer,
         'report_date': fields.String,
         'instance_type': fields.String,
@@ -195,10 +195,8 @@ class HostDetailsApi(Resource):
             record['report_date'] = profile.report_date
             record['cloud_provider'] = system.cloud_provider
             record['instance_type'] = system.instance_type
-            record['idling_time'] = (profile.performance_record['kernel.all.cpu.idle']
-                                     / profile.performance_record['total_cpus']) * 100
-            # This metric has not been updated in our archive yet.
-            record['io_wait'] = profile.performance_record['kernel.all.cpu.wait.total'] * 100
+            record['idling_time'] = profile.idling_time
+            record['io_wait'] = profile.io_wait
         else:
             abort(404, message="System {} doesn't exist"
                   .format(host_id))

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -15,11 +15,31 @@ DEFAULT_OFFSET = 0
 
 
 class HostsApi(Resource):
-
     display_performance_score_fields = {
         'cpu_score': fields.Integer,
         'memory_score': fields.Integer,
         'io_score': fields.Integer
+    }
+    link_key_fields = {
+        'kcs': fields.List,
+        'jira': fields.List
+    }
+    details_fields = {
+        'rhel': fields.String,
+        'type': fields.String,
+        'error_key': fields.String
+        # Are instance_type and cloud_provider needed here too?
+        # We have them below already.
+    }
+    rule_hit_details_fields = {
+        'key': fields.String,
+        'tags': fields.List,
+        'type': fields.String,
+        'links': fields.Nested(link_key_fields),
+        'details': fields.Nested(details_fields),
+        'rule_id': fields.String,
+        'component': fields.String,
+        'system_id': fields.String
     }
     hosts_fields = {
         'fqdn': fields.String,
@@ -33,7 +53,7 @@ class HostsApi(Resource):
         'instance_type': fields.String,
         'idling_time': fields.String,
         'io_wait': fields.String,
-        'rule_hit_details': fields.String
+        'rule_hit_details': fields.List(fields.Nested(rule_hit_details_fields))
     }
     meta_fields = {
         'count': fields.Integer,
@@ -157,9 +177,35 @@ class HostsApi(Resource):
 
 
 class HostDetailsApi(Resource):
+    display_performance_score_fields = {
+        'cpu_score': fields.Integer,
+        'memory_score': fields.Integer,
+        'io_score': fields.Integer
+    }
+    link_key_fields = {
+        'kcs': fields.List,
+        'jira': fields.List
+    }
+    details_fields = {
+        'rhel': fields.String,
+        'type': fields.String,
+        'error_key': fields.String
+        # Are instance_type and cloud_provider needed here too?
+        # We have them below already.
+    }
+    rule_hit_details_fields = {
+        'key': fields.String,
+        'tags': fields.List,
+        'type': fields.String,
+        'links': fields.Nested(link_key_fields),
+        'details': fields.Nested(details_fields),
+        'rule_id': fields.String,
+        'component': fields.String,
+        'system_id': fields.String
+    }
     profile_fields = {
         'inventory_id': fields.String,
-        'display_performance_score': fields.String,
+        'display_performance_score': fields.Nested(display_performance_score_fields),
         'rating': fields.Integer,
         'number_of_recommendations': fields.Integer,
         'state': fields.String,
@@ -168,7 +214,7 @@ class HostDetailsApi(Resource):
         'cloud_provider': fields.String,
         'idling_time': fields.String,
         'io_wait': fields.String,
-        'rule_hit_details': fields.String
+        'rule_hit_details': fields.List(fields.Nested(rule_hit_details_fields))
     }
 
     @marshal_with(profile_fields)

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -20,27 +20,6 @@ class HostsApi(Resource):
         'memory_score': fields.Integer,
         'io_score': fields.Integer
     }
-    link_key_fields = {
-        'kcs': fields.List,
-        'jira': fields.List
-    }
-    details_fields = {
-        'rhel': fields.String,
-        'type': fields.String,
-        'error_key': fields.String
-        # Are instance_type and cloud_provider needed here too?
-        # We have them below already.
-    }
-    rule_hit_details_fields = {
-        'key': fields.String,
-        'tags': fields.List,
-        'type': fields.String,
-        'links': fields.Nested(link_key_fields),
-        'details': fields.Nested(details_fields),
-        'rule_id': fields.String,
-        'component': fields.String,
-        'system_id': fields.String
-    }
     hosts_fields = {
         'fqdn': fields.String,
         'display_name': fields.String,
@@ -53,7 +32,6 @@ class HostsApi(Resource):
         'instance_type': fields.String,
         'idling_time': fields.String,
         'io_wait': fields.String,
-        'rule_hit_details': fields.List(fields.Nested(rule_hit_details_fields))
     }
     meta_fields = {
         'count': fields.Integer,
@@ -182,27 +160,6 @@ class HostDetailsApi(Resource):
         'memory_score': fields.Integer,
         'io_score': fields.Integer
     }
-    link_key_fields = {
-        'kcs': fields.List,
-        'jira': fields.List
-    }
-    details_fields = {
-        'rhel': fields.String,
-        'type': fields.String,
-        'error_key': fields.String
-        # Are instance_type and cloud_provider needed here too?
-        # We have them below already.
-    }
-    rule_hit_details_fields = {
-        'key': fields.String,
-        'tags': fields.List,
-        'type': fields.String,
-        'links': fields.Nested(link_key_fields),
-        'details': fields.Nested(details_fields),
-        'rule_id': fields.String,
-        'component': fields.String,
-        'system_id': fields.String
-    }
     profile_fields = {
         'inventory_id': fields.String,
         'display_performance_score': fields.Nested(display_performance_score_fields),
@@ -213,8 +170,7 @@ class HostDetailsApi(Resource):
         'instance_type': fields.String,
         'cloud_provider': fields.String,
         'idling_time': fields.String,
-        'io_wait': fields.String,
-        'rule_hit_details': fields.List(fields.Nested(rule_hit_details_fields))
+        'io_wait': fields.String
     }
 
     @marshal_with(profile_fields)
@@ -250,7 +206,6 @@ class HostDetailsApi(Resource):
             record['instance_type'] = system.instance_type
             record['idling_time'] = profile.idling_time
             record['io_wait'] = profile.io_wait
-            record['rule_hit_details'] = system.rule_hit_details
             # FIXME
             # record['number_of_recommendations'] = fetch value from db itself
             # record['state] = fetch value from db itself

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -157,10 +157,12 @@ class HostDetailsApi(Resource):
     profile_fields = {
         'host_id': fields.String(attribute='inventory_id'),
         'performance_record': fields.String,
-        'display_performance_score': fields.String,
         'rating': fields.Integer,
-        'recommendation_count': fields.Integer,
-        'state': fields.String
+        'report_date': fields.String,
+        'instance_type': fields.String,
+        'cloud_provider': fields.String,
+        'idling_time': fields.String,
+        'io_wait': fields.String
     }
 
     @marshal_with(profile_fields)
@@ -189,12 +191,16 @@ class HostDetailsApi(Resource):
 
         if profile:
             record = {'inventory_id': host_id}
-            record['display_performance_score'] = profile.display_performance_score
             record['rating'] = rating_record.rating if rating_record else None
-            record['recommendation_count'] = len(system.rule_hit_details)
-            record['state'] = system.rule_hit_details[0].get('key')
+            record['report_date'] = profile.report_date
+            record['cloud_provider'] = system.cloud_provider
+            record['instance_type'] = system.instance_type
+            record['idling_time'] = (profile.performance_record['kernel.all.cpu.idle']
+                                     / profile.performance_record['total_cpus']) * 100
+            # This metric has not been updated in our archive yet.
+            record['io_wait'] = profile.performance_record['kernel.all.cpu.wait.total'] * 100
         else:
-            abort(404, message="Performance Profile {} doesn't exist"
+            abort(404, message="System {} doesn't exist"
                   .format(host_id))
 
         return record

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -32,11 +32,11 @@ class PerformanceProfile(db.Model):
     @property
     def idling_time(self):
         return (self.performance_record['kernel.all.cpu.idle']
-                / self.performance_record['total_cpus']) * 100
+                / self.performance_record['total_cpus'])
 
     @property
     def io_wait(self):
-        return self.performance_record['kernel.all.cpu.wait.total'] * 100
+        return self.performance_record['kernel.all.cpu.wait.total']
 
 
 class System(db.Model):

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -29,6 +29,15 @@ class PerformanceProfile(db.Model):
 
         return display_performance_score
 
+    @property
+    def idling_time(self):
+        return (self.performance_record['kernel.all.cpu.idle']
+                / self.performance_record['total_cpus']) * 100
+
+    @property
+    def io_wait(self):
+        return self.performance_record['kernel.all.cpu.wait.total'] * 100
+
 
 class System(db.Model):
     __tablename__ = 'systems'

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -31,8 +31,10 @@ class PerformanceProfile(db.Model):
 
     @property
     def idling_time(self):
-        return (self.performance_record['kernel.all.cpu.idle']
-                / self.performance_record['total_cpus'])
+        idling_percent = (self.performance_record['kernel.all.cpu.idle']
+                          / self.performance_record['total_cpus']) * 100
+        # idling % of 24 hours and converting hours into mins
+        return 24 * (idling_percent / 100) * 60
 
     @property
     def io_wait(self):

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -31,10 +31,8 @@ class PerformanceProfile(db.Model):
 
     @property
     def idling_time(self):
-        idling_percent = (self.performance_record['kernel.all.cpu.idle']
-                          / self.performance_record['total_cpus']) * 100
-        # idling % of 24 hours and converting hours into mins
-        return 24 * (idling_percent / 100) * 60
+        return ((float(self.performance_record['kernel.all.cpu.idle']) * 100)
+                / int(self.performance_record['total_cpus']))
 
     @property
     def io_wait(self):


### PR DESCRIPTION
Added response fields as per the mockup here: https://marvelapp.com/prototype/9408d9j/screen/74816603.
EDIT:

- [x] Add missing fields in **both** APIs such as `idling_time`, `io_wait`, `rule_hit_details`, `cloud_provider`, `report_date`, `instance_type`.
- [x] Pending existing fields such as `recommendation_count` and `state` to be displayed after #55 is merged.
- [x] Renamed `recommendation_count` to `number_of_recommendations`.
- [x] HostDetailsAPI will display host id with `inventory_id` as the key.