### PR TITLE
RHIROS-81 Implement basic filtering for systems

### DIFF
--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -61,6 +61,9 @@ class HostsApi(Resource):
         ).strip().lower()
         order_how = (request.args.get('order_how') or 'asc').strip().lower()
 
+        # if query string is passed with display_name
+        filter_display_name = request.args.get('display_name')
+
         ident = identity(request)['identity']
         # Note that When using LIMIT, it is important to use an ORDER BY clause
         # that constrains the result rows into a unique order.
@@ -106,6 +109,11 @@ class HostsApi(Resource):
             host['account'] = row.RhAccount.account
             host['display_performance_score'] = row.PerformanceProfile.display_performance_score
             hosts.append(host)
+            # for filtering get the request param and check
+            if filter_display_name and host['display_name'] == filter_display_name:
+                hosts = []
+                hosts.append(host)
+                break
 
         return build_paginated_system_list_response(
             limit, offset, hosts, count

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -71,8 +71,8 @@ class HostsApi(Resource):
         account_query = db.session.query(RhAccount.id).filter(RhAccount.account == ident['account_number']).subquery()
         if filter_display_name:
             system_query = db.session.query(System.id)\
-                .filter(System.account_id.in_(account_query))\
-                .filter(System.display_name == filter_display_name)
+                .filter(System.display_name.ilike(f'%{filter_display_name}%'))\
+                .filter(System.account_id.in_(account_query))
         else:
             system_query = db.session.query(System.id)\
                 .filter(System.account_id.in_(account_query))

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -53,13 +53,7 @@
                         "$ref": "#/components/parameters/orderHowParam"
                     },
                     {
-                        "name": "filter[display_name]",
-                        "in": "query",
-                        "required": false,
-                        "description": "Filter ",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "$ref": "#/components/parameters/filterParam"
                     }
                 ],
                 "responses": {
@@ -364,6 +358,15 @@
                         "ASC",
                         "DESC"
                     ]
+                }
+            },
+            "filterParam": {
+                "name": "filter[display_name]",
+                "in": "query",
+                "required": false,
+                "description": "Filter system with the given display name ",
+                "schema": {
+                    "type": "string"
                 }
             }
 

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -361,7 +361,7 @@
                 }
             },
             "filterParam": {
-                "name": "filter[display_name]",
+                "name": "display_name",
                 "in": "query",
                 "required": false,
                 "description": "Filter system with the given display name ",

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -51,6 +51,15 @@
                     },
                     {
                         "$ref": "#/components/parameters/orderHowParam"
+                    },
+                    {
+                        "name": "filter[display_name]",
+                        "in": "query",
+                        "required": false,
+                        "description": "Filter ",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
Currently, it works fine for API. For example if we hit: `curl -v -H "Content-Type: application/json"  -H "x-rh-identity: ${b64_identity}" localhost:8080/api/ros/v0/systems?display_name=ap-172-31-11-67.ap-south-1.compute.internal | python -m json.tool`