### PR TITLE
Added insights-engine in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The application depends on several parts of the insights platform. These depende
 
 To run the dependencies, just run following command:
 ```bash
-cd scripts && docker-compose up insights-inventory-web db-ros
+cd scripts && docker-compose up insights-inventory-web db-ros insights-engine
 ```
 ## Running the ROS application
 ### Within docker

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,7 @@ docker login quay.io
 4. Start dependency containers (insight-sinventory-web has dependency on all platform containers, so they can be started with a single command).
 The db-ros container just provides a PostgreSQL database for the ROS application
 ```bash
-docker-compose up --build insights-inventory-web db-ros
+docker-compose up --build insights-inventory-web db-ros insights-engine
 ```
 
 ## Usage

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -19,6 +19,17 @@ services:
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+  # Below container is to implement workaround for creating required topics.
+  kafka-create-topics:
+    image: confluentinc/cp-kafka
+    ports:
+      - 7777:29092
+    command: "bash -c 'echo Waiting for Kafka to be ready... && \
+                       cub kafka-ready -b kafka:29092 1 20 && \
+                       kafka-topics --create --if-not-exists --topic platform.inventory.events --bootstrap-server kafka:29092 && \
+                       kafka-topics --create --if-not-exists --topic platform.engine.results --bootstrap-server kafka:29092'"
+    depends_on:
+      - kafka
   minio:
     image: minio/minio
     command: server /data
@@ -97,7 +108,7 @@ services:
       - PAYLOAD_TRACKER_ENABLED=false
       - LISTEN_PORT=8081
     depends_on:
-       - kafka
+       - kafka-create-topics
        - db-host-inventory
        - puptoo
        - createbuckets
@@ -126,6 +137,13 @@ services:
     volumes:
       - './cdappconfig.json:/cdappconfig.json:Z'
 
+  insights-engine:
+    image: quay.io/cloudservices/insights-engine:latest
+    restart: always
+    depends_on:
+      - puptoo
+      - kafka-create-topics
+      - insights-inventory-mq
   # Allows us to run the application in the form it's going to be deployed, will be needed for tests
   ros-processor: &ros
     build:
@@ -133,6 +151,7 @@ services:
     command: [ "python", "-m", "ros.processor.main" ]
     depends_on:
       - insights-inventory-web
+      - insights-engine
       - kafka
       - createbuckets
     environment:


### PR DESCRIPTION
Running `# docker-compose up insights-inventory-web db-ros insights-engine` may give the below warning but it can be ignored. 
`insights-engine_1         | KafkaError{code=UNKNOWN_TOPIC_OR_PART,val=3,str="Subscribed topic not available: platform.inventory.events: Broker: Unknown topic or partition"}`

This PR also solve the issue of creating required topics at the time of initialization. 