### PR TITLE
RHIROS-111 Add exception to fetch model level attributes

### DIFF
--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -8,7 +8,9 @@ from ros.lib.models import (
     db, RecommendationRating)
 from ros.lib.utils import is_valid_uuid, identity, user_data_from_identity
 from ros.api.common.pagination import build_paginated_system_list_response
+import logging
 
+LOG = logging.getLogger(__name__)
 
 DEFAULT_HOSTS_PER_REP = 10
 DEFAULT_OFFSET = 0
@@ -103,14 +105,19 @@ class HostsApi(Resource):
             'instance_type', 'cloud_provider',
             'rule_hit_details', 'state', 'number_of_recommendations']
         for row in query_results:
-            system_dict = row.System.__dict__
-            host = {skey: system_dict[skey] for skey in system_columns}
-            host['account'] = row.RhAccount.account
-            host['display_performance_score'] = row.PerformanceProfile.display_performance_score
-            host['idling_time'] = row.PerformanceProfile.idling_time
-            host['io_wait'] = row.PerformanceProfile.io_wait
-            hosts.append(host)
-
+            try:
+                system_dict = row.System.__dict__
+                host = {skey: system_dict[skey] for skey in system_columns}
+                host['account'] = row.RhAccount.account
+                host['display_performance_score'] = row.PerformanceProfile.display_performance_score
+                host['idling_time'] = row.PerformanceProfile.idling_time
+                host['io_wait'] = row.PerformanceProfile.io_wait
+                hosts.append(host)
+            except Exception as err:
+                LOG.error(
+                    'An error occured while fetching the host. %s',
+                    repr(err)
+                )
         return build_paginated_system_list_response(
             limit, offset, hosts, count
         )

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -31,14 +31,16 @@ class PerformanceProfile(db.Model):
 
     @property
     def idling_time(self):
-        idling_percent = ((float(self.performance_record['kernel.all.cpu.idle']) * 100)
-                          / int(self.performance_record['total_cpus']))
-        return "%0.2f" % idling_percent
+        if 'kernel.all.cpu.idle' in self.performance_record:
+            idling_percent = ((float(self.performance_record['kernel.all.cpu.idle']) * 100)
+                              / int(self.performance_record['total_cpus']))
+            return "%0.2f" % idling_percent
 
     @property
     def io_wait(self):
-        io_wait = self.performance_record['kernel.all.cpu.wait.total'] * 100
-        return "%0.2f" % io_wait
+        if 'kernel.all.cpu.wait.total' in self.performance_record:
+            io_wait = self.performance_record['kernel.all.cpu.wait.total'] * 100
+            return "%0.2f" % io_wait
 
 
 class System(db.Model):


### PR DESCRIPTION
To handle the following exceptions:
```
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/app-root/lib64/python3.8/site-packages/flask_restful/__init__.py", line 468, in wrapper
    resp = resource(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/flask_restful/__init__.py", line 583, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/flask_restful/__init__.py", line 675, in wrapper
    resp = f(*args, **kwargs)
  File "/home/apuntamb/cloud_services/ros-backend/ros/api/v0/hosts.py", line 110, in get
    host['idling_time'] = row.PerformanceProfile.idling_time
  File "/home/apuntamb/cloud_services/ros-backend/ros/lib/models.py", line 35, in idling_time
    idling_percent = ((float(self.performance_record['kernel.all.cpu.idle']) * 100)
KeyError: 'kernel.all.cpu.idle'
  File "/opt/app-root/src/ros/api/v0/hosts.py", line 111, in get
    host['io_wait'] = row.PerformanceProfile.io_wait
  File "/opt/app-root/src/ros/lib/models.py", line 40, in io_wait
    io_wait = self.performance_record['kernel.all.cpu.wait.total'] * 100
KeyError: 'kernel.all.cpu.wait.total'
```