### PR TITLE
API to list historical performance data

### DIFF
--- a/ros/api/routes.py
+++ b/ros/api/routes.py
@@ -1,4 +1,4 @@
-from .v0.hosts import HostsApi, HostDetailsApi
+from .v0.hosts import HostsApi, HostDetailsApi, HostHistoryApi
 from .v0.recommendation_ratings import RecommendationRatingsApi
 from .v0.recommendations import RecommendationsApi
 from .v0.openapi_spec import OpenAPISpec
@@ -9,6 +9,7 @@ from .v0.status import Status
 def initialize_routes(api):
     api.add_resource(Status, '/api/ros/v0/status')
     api.add_resource(HostsApi, '/api/ros/v0/systems')
+    api.add_resource(HostHistoryApi, '/api/ros/v0/systems/<host_id>/history')
     api.add_resource(RecommendationsApi, '/api/ros/v0/systems/<host_id>/recommendations')
     api.add_resource(HostDetailsApi, '/api/ros/v0/systems/<host_id>')
     api.add_resource(RecommendationRatingsApi, '/api/ros/v0/rating')

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -222,3 +222,71 @@ class HostDetailsApi(Resource):
                   .format(host_id))
 
         return record
+
+
+class HostHistoryApi(Resource):
+    display_performance_score_fields = {
+        'cpu_score': fields.Integer,
+        'memory_score': fields.Integer,
+        'io_score': fields.Integer,
+        'report_date':  fields.String
+    }
+
+    data_fields = {
+        'inventory_id': fields.String,
+        'performance_history': fields.List(fields.Nested(display_performance_score_fields))
+    }
+    meta_fields = {
+        'count': fields.Integer,
+        'limit': fields.Integer,
+        'offset': fields.Integer
+    }
+    links_fields = {
+        'first': fields.String,
+        'last': fields.String,
+        'next': fields.String,
+        'previous': fields.String
+    }
+    history_fields = {
+        'meta': fields.Nested(meta_fields),
+        'links': fields.Nested(links_fields),
+        'data': fields.Nested(data_fields)
+    }
+
+    @marshal_with(history_fields)
+    def get(self, host_id):
+        limit = int(request.args.get('limit') or DEFAULT_HOSTS_PER_REP)
+        offset = int(request.args.get('offset') or DEFAULT_OFFSET)
+        if not is_valid_uuid(host_id):
+            abort(404, message='Invalid host_id, Id should be in form of UUID4')
+
+        ident = identity(request)['identity']
+
+        account_query = db.session.query(RhAccount.id).filter(RhAccount.account == ident['account_number']).subquery()
+        system_query = db.session.query(System.id) \
+            .filter(System.account_id.in_(account_query)).filter(System.inventory_id == host_id).subquery()
+
+        query = PerformanceProfile.query.filter(
+            PerformanceProfile.system_id.in_(system_query)
+        ).order_by(PerformanceProfile.report_date.desc())
+
+        count = query.count()
+        query = query.limit(limit).offset(offset)
+        query_results = query.all()
+
+        if query_results:
+            performance_history = []
+            for profile in query_results:
+                performance_record = profile.display_performance_score
+                performance_record['report_date'] = profile.report_date
+                performance_history.append(performance_record)
+
+            record = {'inventory_id': host_id}
+            record['performance_history'] = performance_history
+        else:
+            abort(404, message="System {} doesn't exist"
+                  .format(host_id))
+
+        return build_paginated_system_list_response(
+            limit, offset, record, count
+        )

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -232,9 +232,6 @@ class HostHistoryApi(Resource):
         'report_date':  fields.String
     }
 
-    data_fields = {
-        'performance_history': fields.List(fields.Nested(display_performance_score_fields))
-    }
     meta_fields = {
         'count': fields.Integer,
         'limit': fields.Integer,
@@ -250,7 +247,7 @@ class HostHistoryApi(Resource):
         'meta': fields.Nested(meta_fields),
         'links': fields.Nested(links_fields),
         'inventory_id': fields.String,
-        'data': fields.Nested(data_fields)
+        'data': fields.List(fields.Nested(display_performance_score_fields))
     }
 
     @marshal_with(history_fields)
@@ -284,10 +281,8 @@ class HostHistoryApi(Resource):
             performance_record['report_date'] = profile.report_date
             performance_history.append(performance_record)
 
-        record = {'performance_history': performance_history}
-
         paginated_response = build_paginated_system_list_response(
-            limit, offset, record, count
+            limit, offset, performance_history, count
         )
         paginated_response['inventory_id'] = host_id
         return paginated_response

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -104,6 +104,35 @@
                 }
             }
         },
+        "/systems/{inventory_id}/history": {
+            "get": {
+                "summary": "Show the system's performance history by given inventory id",
+                "description": "Show the system's performance history by given inventory id",
+                "parameters": [
+                    {
+                        "name": "inventory_id",
+                        "in": "path",
+                        "description": "Inventory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PerformanceHistory"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/systems/{inventory_id}/recommendations": {
             "get": {
                 "summary": "Show the list of recommendations by given inventory id",
@@ -345,6 +374,40 @@
                     },
                     "io_wait": {
                         "type": "number"
+                    }
+                }
+            },
+            "PerformanceHistory": {
+                "type": "object",
+                "properties": {
+                    "meta": {
+                        "$ref": "#/components/schemas/ListMeta"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/Links"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PerformanceItem"
+                        }
+                    }
+                }
+            },
+            "PerformanceItem": {
+                "type": "object",
+                "properties": {
+                    "cpu_score": {
+                        "type": "integer"
+                    },
+                    "memory_score": {
+                        "type": "integer"
+                    },
+                    "io_score": {
+                        "type": "integer"
+                    },
+                    "report_date": {
+                        "type": "string"
                     }
                 }
             },


### PR DESCRIPTION
API output looks like below - 

```
{
    "meta": {
        "count": 3,
        "limit": 10,
        "offset": 0
    },
    "links": {
        "first": "/api/ros/v0/systems/02c4bc40-e507-4b35-a321-732bfe74ba91/history?limit=10&offset=0",
        "last": "/api/ros/v0/systems/02c4bc40-e507-4b35-a321-732bfe74ba91/history?limit=10&offset=0",
        "next": null,
        "previous": null
    },
    "data": {
        "inventory_id": "02c4bc40-e507-4b35-a321-732bfe74ba91",
        "performance_history": [
            {
                "cpu_score": 1,
                "memory_score": 3,
                "io_score": 1,
                "report_date": "2021-05-18"
            },
            {
                "cpu_score": 1,
                "memory_score": 3,
                "io_score": 1,
                "report_date": "2021-05-17"
            },
            {
                "cpu_score": 5,
                "memory_score": 3,
                "io_score": 5,
                "report_date": "2021-05-16"
            }
        ]
    }
}
```