### PR TITLE
RHIROS #239 - Add log to trace system during exception

### DIFF
--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -64,9 +64,11 @@ class InventoryEventsConsumer:
                 )
             except Exception as err:
                 LOG.error(
-                    'An error occurred during message processing: %s - %s',
+                    'An error occurred during message processing: %s in the system %s created from account: %s - %s',
                     repr(err),
-                    self.prefix
+                    msg['host']['id'],
+                    msg['host']['account'],
+                    self.prefix,
                 )
             finally:
                 self.consumer.commit()


### PR DESCRIPTION
This commit only enhances the existing log to trace the system and account that have triggered  the exception.

In case of an Exception:
1) If no platform_metadata key (not usually the case, but will be covered in the exception), you can see this output:
```
2021-08-09 21:55:41,102 - ERROR  - run - An error occurred during message processing: KeyError('platform_metadata') in the system 80222848-6007-4753-b91e-2659fa501f8d created from account: 0000001 - PROCESSING Create/Update EVENT
10:34
```
2) If `platform_metadata: None`, you can see:
```
2021-08-09 22:34:04,128 - ERROR  - run - An error occurred during message processing: TypeError("argument of type 'NoneType' is not iterable") in the system a694e7af-743b-45ab-8399-d69e1f98a44d created from account: 0000001 - PROCESSING Create/Update EVENT
10:36
```
