### PR TITLE
Remove DB section from cdappconfig

### DIFF
--- a/cdappconfig.json
+++ b/cdappconfig.json
@@ -1,13 +1,4 @@
 {
-    "database": {
-        "adminPassword": "QM2FppyaTcYBcXtl",
-        "adminUsername": "postgres",
-        "hostname": "localhost",
-        "name": "postgres",
-        "password": "postgres",
-        "port": 15432,
-        "username": "postgres"
-    },
     "kafka": {
         "brokers": [
             {


### PR DESCRIPTION
Currently, there's no JIRA associated with this PR as it is based on the security alarm raised because of the password present in this file. Although, it is a dummy password, it would be wise to remove it from the file. Secondly, according to https://consoledot.pages.redhat.com/docs/dev/getting-started/migration/config.html#_cdappconfig, this file is generated by clowder. So, not sure if we do want to create it explicitly in our repo.

Based on further discussions, will create a corresponding JIRA as required.