### PR TITLE
RHIROS-357 | REMOVE - OpenAPI servers drop-down has template string

### DIFF
--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -10,11 +10,6 @@
         },
         "version": "v0.1"
     },
-    "servers": [
-        {
-            "url": "{{ PATH_PREFIX }}/{{ APP_NAME }}/v0"
-        }
-    ],
     "paths": {
         "/status": {
             "get": {


### PR DESCRIPTION
Changes:
1. Removed servers object from openapi.json file

Reasons:
1. Getting auto-magically generated; checked on ci.foo and qa.foo via local setup

Issue:
The template string for the servers object was appearing as the default value on the drop-down for Servers:
Hence, the test calls were failing.