### PR TITLE
RHIROS #387 - Increase kafka consumer timeouts

### DIFF
--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -22,7 +22,9 @@ class InventoryEventsConsumer:
         self.consumer = Consumer({
             'bootstrap.servers': INSIGHTS_KAFKA_ADDRESS,
             'group.id': GROUP_ID,
-            'enable.auto.commit': False
+            'enable.auto.commit': False,
+            'session.timeout.ms': 90000,  # default 45000 (45 seconds)
+            'heartbeat.interval.ms': 10000  # default 3000 (3 seconds)
         })
 
         # Subscribe to topic


### PR DESCRIPTION
Based on the kafka logs as described in the JIRA ticket, bumping the timeout values up would be a good test.
Reference doc - https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#consumerconfigs_heartbeat.interval.ms