### PR TITLE
RHIROS-401 Update archive processor to store new metrics

### DIFF
--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -183,16 +183,11 @@ class InventoryEventsConsumer:
                 LOG.error("%s - Unable to add host %s to DB belonging to account: %s - %s",
                           self.prefix, host['fqdn'], host['account'], err)
 
+    # TODO -temporary values are assigned to both score and utilization.
     def _calculate_performance_utilization(self, performance_record, host):
-        MAX_IOPS_CAPACITY = 16000
-        memory_utilized = (float(performance_record['mem.util.used']) / float(performance_record['mem.physmem'])) * 100
-        cpu_utilized = self._calculate_cpu_score(performance_record)
-        cloud_provider = host['system_profile']['cloud_provider']
-        if cloud_provider == 'aws':
-            MAX_IOPS_CAPACITY = 16000
-        if cloud_provider == 'azure':
-            MAX_IOPS_CAPACITY = 20000
-        io_utilized = (float(performance_record['disk.all.total']) / float(MAX_IOPS_CAPACITY)) * 100
+        memory_utilized = 0
+        cpu_utilized = 0
+        io_utilized = 0
         performance_utilization = {
             'memory': int(memory_utilized),
             'cpu': int(cpu_utilized),
@@ -201,7 +196,6 @@ class InventoryEventsConsumer:
         return performance_utilization
 
     def _calculate_cpu_score(self, performance_record):
-        idle_cpu_percent = ((float(performance_record['kernel.all.cpu.idle']) * 100)
-                            / int(performance_record['total_cpus']))
+        idle_cpu_percent = 0
         cpu_utilized_percent = 100 - idle_cpu_percent
         return cpu_utilized_percent

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -196,6 +196,7 @@ class InventoryEventsConsumer:
         return performance_utilization
 
     def _calculate_cpu_score(self, performance_record):
-        idle_cpu_percent = 0
+        idle_cpu_percent = ((float(performance_record['kernel.all.cpu.idle']) * 100)
+                            / int(performance_record['total_cpus']))
         cpu_utilized_percent = 100 - idle_cpu_percent
         return cpu_utilized_percent

--- a/ros/processor/process_archive.py
+++ b/ros/processor/process_archive.py
@@ -26,22 +26,24 @@ def performance_profile(lscpu, aws_instance_id, azure_instance_type, pmlog_summa
     profile = {}
     if pmlog_summary is not None:
         performance_metrics = [
+            'hinv.ncpu',
             'mem.physmem',
-            'mem.util.used',
-            'kernel.all.cpu.user',
-            'kernel.all.cpu.sys',
-            'kernel.all.cpu.nice',
-            'kernel.all.cpu.steal',
+            'mem.util.available',
+            'disk.dev.total',
             'kernel.all.cpu.idle',
-            'kernel.all.cpu.wait.total',
-            'disk.all.total',
-            'mem.util.cached',
-            'mem.util.bufmem',
-            'mem.util.free'
+            'kernel.all.pressure.cpu.some.avg',
+            'kernel.all.pressure.io.full.avg',
+            'kernel.all.pressure.io.some.avg',
+            'kernel.all.pressure.memory.full.avg',
+            'kernel.all.pressure.memory.some.avg',
             ]
         for i in performance_metrics:
-            profile[i] = _.get(pmlog_summary, f'{i}.val')
-
+            if i != 'disk.dev.total':
+                profile[i] = _.get(pmlog_summary, f'{i}.val')
+        disks_object = _.get(pmlog_summary, 'disk.dev.total')
+        for i in disks_object:
+            disk = 'disk.dev.total' + f'.{i}'
+            profile[disk] = _.get(pmlog_summary, f'{disk}.val')
     profile["total_cpus"] = int(lscpu.info.get('CPUs'))
     if aws_instance_id:
         profile["instance_type"] = aws_instance_id.get('instanceType')

--- a/ros/processor/process_archive.py
+++ b/ros/processor/process_archive.py
@@ -36,14 +36,13 @@ def performance_profile(lscpu, aws_instance_id, azure_instance_type, pmlog_summa
             'kernel.all.pressure.io.some.avg',
             'kernel.all.pressure.memory.full.avg',
             'kernel.all.pressure.memory.some.avg',
-            ]
+        ]
         for i in performance_metrics:
-            if i != 'disk.dev.total':
+            if i in ['hinv.ncpu', 'mem.physmem', 'mem.util.available', 'kernel.all.cpu.idle']:
                 profile[i] = _.get(pmlog_summary, f'{i}.val')
-        disks_object = _.get(pmlog_summary, 'disk.dev.total')
-        for i in disks_object:
-            disk = 'disk.dev.total' + f'.{i}'
-            profile[disk] = _.get(pmlog_summary, f'{disk}.val')
+            else:
+                profile[i] = _.get(pmlog_summary, i)
+
     profile["total_cpus"] = int(lscpu.info.get('CPUs'))
     if aws_instance_id:
         profile["instance_type"] = aws_instance_id.get('instanceType')

--- a/tests/test_inventory_events_consumer.py
+++ b/tests/test_inventory_events_consumer.py
@@ -47,7 +47,7 @@ def test_process_system_details(inventory_event_consumer, inventory_event_messag
 
 
 def test_calculate_performance_utilization(inventory_event_consumer, inventory_event_message):
-    expected_utilization = {'memory': 80, 'cpu': 0, 'io': 0}
+    expected_utilization = {'memory': 0, 'cpu': 0, 'io': 0}
     utilization = inventory_event_consumer._calculate_performance_utilization(
         PERFORMANCE_RECORD, inventory_event_message['host']
     )
@@ -55,6 +55,6 @@ def test_calculate_performance_utilization(inventory_event_consumer, inventory_e
 
 
 def test_calculate_cpu_score(inventory_event_consumer):
-    expected_result = 0.5999999999999943
+    expected_result = 100
     result = inventory_event_consumer._calculate_cpu_score(PERFORMANCE_RECORD)
     assert expected_result == result

--- a/tests/test_inventory_events_consumer.py
+++ b/tests/test_inventory_events_consumer.py
@@ -44,17 +44,3 @@ def test_process_system_details(inventory_event_consumer, inventory_event_messag
     inventory_event_consumer.process_system_details(inventory_event_message)
     host = db_get_host(inventory_event_message['host']['id'])
     assert str(host.inventory_id) == inventory_event_message['host']['id']
-
-
-def test_calculate_performance_utilization(inventory_event_consumer, inventory_event_message):
-    expected_utilization = {'memory': 0, 'cpu': 0, 'io': 0}
-    utilization = inventory_event_consumer._calculate_performance_utilization(
-        PERFORMANCE_RECORD, inventory_event_message['host']
-    )
-    assert expected_utilization == utilization
-
-
-def test_calculate_cpu_score(inventory_event_consumer):
-    expected_result = 100
-    result = inventory_event_consumer._calculate_cpu_score(PERFORMANCE_RECORD)
-    assert expected_result == result


### PR DESCRIPTION
Now the `profile` object in process_archive will contain new metrics with their respective values except `disk.dev.total` and `kernel.all` type metrics which will store its value as an object. This is because we're not processing or using these metrics anywhere in our ros-backend. We're just storing in ros db as performance_record in `performance_profile` table.

Refer the below profile object.
`{
	"hinv.ncpu": 8.0,
	"total_cpus": 1,
	"mem.physmem": 32617072.0,
	"instance_type": "t2.micro",
	"disk.dev.total": {
		"nvme0n1": {
			"val": 7.22,
			"units": "count / sec"
		}
	},
	"mem.util.available": 27455175.254,
	"kernel.all.cpu.idle": 7.55,
	"kernel.all.pressure.io.full.avg": {
		"1 minute": {
			"val": 0.006,
			"units": "none"
		},
		"5 minute": {
			"val": 0.004,
			"units": "none"
		},
		"10 second": {
			"val": 0.012,
			"units": "none"
		}
	},
	"kernel.all.pressure.io.some.avg": {
		"1 minute": {
			"val": 0.006,
			"units": "none"
		},
		"5 minute": {
			"val": 0.004,
			"units": "none"
		},
		"10 second": {
			"val": 0.013,
			"units": "none"
		}
	},
	"kernel.all.pressure.cpu.some.avg": {
		"1 minute": {
			"val": 0.575,
			"units": "none"
		},
		"5 minute": {
			"val": 0.572,
			"units": "none"
		},
		"10 second": {
			"val": 0.579,
			"units": "none"
		}
	},
	"kernel.all.pressure.memory.full.avg": {
		"1 minute": {
			"val": 0.0,
			"units": "none"
		},
		"5 minute": {
			"val": 0.0,
			"units": "none"
		},
		"10 second": {
			"val": 0.0,
			"units": "none"
		}
	},
	"kernel.all.pressure.memory.some.avg": {
		"1 minute": {
			"val": 0.0,
			"units": "none"
		},
		"5 minute": {
			"val": 0.0,
			"units": "none"
		},
		"10 second": {
			"val": 0.0,
			"units": "none"
		}
	}
}`


### Testing
To test this change with an archive with new metrics it uses utilization and score values (which are currently using old metrics for calculation). For now set these values as zero in `inventory event processor` file for testing .