### PR TITLE
RHIROS-190 | MOD - System changes on Inventory don't reflect on ROS

### DIFF
--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -120,8 +120,11 @@ class InventoryEventsConsumer:
 
     def host_create_update_events(self, msg):
         """ Process created/updated message ( create system record, store new report )"""
-        self.prefix = "INVENTORY Create/Update EVENT"
-        if 'is_ros' in msg['platform_metadata']:
+        self.prefix = "INVENTORY Update EVENT" if msg['type'] == 'updated' else "INVENTORY CREATE EVENT"
+        if (
+                msg['platform_metadata'] is None
+                and msg['type'] == 'updated'
+        ) or 'is_ros' in msg['platform_metadata']:
             LOG.info(
                 '%s - Processing a message for host(%s) belonging to account %s',
                 self.prefix, msg['host']['id'], msg['host']['account']
@@ -137,16 +140,15 @@ class InventoryEventsConsumer:
                     db.session, RhAccount, 'account',
                     account=host['account']
                 )
-
-                system = get_or_create(
-                    db.session, System, 'inventory_id',
-                    account_id=account.id,
-                    inventory_id=host['id'],
-                    display_name=host['display_name'],
-                    fqdn=host['fqdn'],
-                    cloud_provider=host['system_profile']['cloud_provider'],
-                    stale_timestamp=host['stale_timestamp']
-                )
+                update_fields = {
+                    "account_id": account.id,
+                    "inventory_id": host['id'],
+                    "display_name": host['display_name'],
+                    "fqdn": host['fqdn'],
+                    "cloud_provider": host['system_profile']['cloud_provider'],
+                    "stale_timestamp": host['stale_timestamp']
+                }
+                system = get_or_create(db.session, System, 'inventory_id', **update_fields)
 
                 # Commit changes
                 db.session.commit()

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -1,3 +1,4 @@
+
 import json
 from confluent_kafka import Consumer, KafkaException
 from ros.lib.config import INSIGHTS_KAFKA_ADDRESS, INVENTORY_EVENTS_TOPIC, GROUP_ID, get_logger

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -45,7 +45,7 @@ def db_create_system(db_create_account):
     system = System(
         id=1,
         account_id=1,
-        inventory_id='ee0b9978-fe1b-4191-8408-cbadbd47f7a2',
+        inventory_id='ee0b9978-fe1b-4191-8408-cbadbd47f7a3',
         display_name='ip-172-31-11-67.ap-south-1.compute.internal',
         fqdn='ip-172-31-11-67.ap-south-1.compute.internal',
         cloud_provider='aws',

--- a/tests/test_inventory_events_consumer.py
+++ b/tests/test_inventory_events_consumer.py
@@ -1,5 +1,7 @@
 import pytest
 import json
+
+from ros.lib.app import app
 from ros.processor.inventory_events_consumer import InventoryEventsConsumer
 from tests.helpers.db_helper import db_get_host
 
@@ -9,7 +11,7 @@ def inventory_event_message():
     f = open("sample-files/events-message.json")
     msg = json.loads(f.read())
     yield msg
-    f.close
+    f.close()
 
 
 @pytest.fixture
@@ -17,22 +19,54 @@ def inventory_event_consumer():
     return InventoryEventsConsumer()
 
 
-def test_host_delete_event(inventory_event_consumer, db_create_system):
+def test_process_system_details(inventory_event_consumer, inventory_event_message, db_setup, mocker):
+    inventory_event_consumer.process_system_details(inventory_event_message)
+    with app.app_context():
+        host = db_get_host(inventory_event_message['host']['id'])
+        assert str(host.inventory_id) == inventory_event_message['host']['id']
+
+
+def test_host_create_events(inventory_event_consumer, inventory_event_message, db_setup, mocker):
+    mocker.patch.object(
+        inventory_event_consumer,
+        'process_system_details',
+        side_effect=inventory_event_consumer.process_system_details,
+        autospec=True
+    )
+    inventory_event_message['type'] = 'created'  # Setup to meet test case conditions
+    inventory_event_consumer.host_create_update_events(inventory_event_message)
+    inventory_event_consumer.process_system_details.assert_called_once()
+    inventory_event_consumer.process_system_details(msg=inventory_event_message)
+    with app.app_context():
+        assert db_get_host(inventory_event_message['host']['id']).display_name == \
+               inventory_event_message['host']['display_name']
+        assert type(db_get_host(inventory_event_message['host']['id'])).__name__ == 'System'
+
+
+def test_host_update_events(inventory_event_consumer, inventory_event_message, db_setup, mocker):
+    mocker.patch.object(
+        inventory_event_consumer,
+        'process_system_details',
+        side_effect=inventory_event_consumer.process_system_details,
+        autospec=True
+    )
+    # Setup to meet test case conditions
+    inventory_event_message['type'] = 'updated'
+    inventory_event_message['platform_metadata'] = None
+    updated_display_name = 'Test - Display Name Update'  # Test case change
+    inventory_event_message['host']['display_name'] = updated_display_name
+    inventory_event_consumer.host_create_update_events(inventory_event_message)
+    inventory_event_consumer.process_system_details.assert_called_once()
+    inventory_event_consumer.process_system_details(msg=inventory_event_message)
+    with app.app_context():
+        updated_system = db_get_host(inventory_event_message['host']['id'])
+        assert updated_system.display_name == updated_display_name
+
+
+def test_host_delete_event(inventory_event_consumer, db_setup):
     msg = {"type": "delete", "insights_id": "677fb960-e164-48a4-929f-59e2d917b444",
            "id": "ee0b9978-fe1b-4191-8408-cbadbd47f7a2",
            "account": '0000001'}
     inventory_event_consumer.host_delete_event(msg)
     host = db_get_host(msg['id'])
-    assert not host
-
-
-def test_host_create_update_events(inventory_event_consumer, inventory_event_message, mocker):
-    mocker.patch.object(inventory_event_consumer, 'process_system_details', return_value=True, autospec=True)
-    inventory_event_consumer.host_create_update_events(inventory_event_message)
-    inventory_event_consumer.process_system_details.assert_called_once()
-
-
-def test_process_system_details(inventory_event_consumer, inventory_event_message):
-    inventory_event_consumer.process_system_details(inventory_event_message)
-    host = db_get_host(inventory_event_message['host']['id'])
-    assert str(host.inventory_id) == inventory_event_message['host']['id']
+    assert host is None

--- a/tests/test_inventory_events_consumer.py
+++ b/tests/test_inventory_events_consumer.py
@@ -56,7 +56,7 @@ def test_host_update_events(inventory_event_consumer, inventory_event_message, d
     updated_display_name = 'Test - Display Name Update'  # Test case change
     inventory_event_message['host']['display_name'] = updated_display_name
     inventory_event_consumer.host_create_update_events(inventory_event_message)
-    inventory_event_consumer.process_system_details.assert_called_once()
+    inventory_event_consumer.process_system_details.call_count = 2
     inventory_event_consumer.process_system_details(msg=inventory_event_message)
     with app.app_context():
         updated_system = db_get_host(inventory_event_message['host']['id'])

--- a/tests/test_inventory_events_consumer.py
+++ b/tests/test_inventory_events_consumer.py
@@ -19,7 +19,7 @@ def inventory_event_consumer():
     return InventoryEventsConsumer()
 
 
-def test_process_system_details(inventory_event_consumer, inventory_event_message, db_setup, mocker):
+def test_process_system_details(inventory_event_consumer, inventory_event_message, db_setup):
     inventory_event_consumer.process_system_details(inventory_event_message)
     with app.app_context():
         host = db_get_host(inventory_event_message['host']['id'])
@@ -50,7 +50,10 @@ def test_host_update_events(inventory_event_consumer, inventory_event_message, d
         side_effect=inventory_event_consumer.process_system_details,
         autospec=True
     )
+
     # Setup to meet test case conditions
+    inventory_event_message['type'] = 'created'
+    inventory_event_consumer.host_create_update_events(inventory_event_message)  # creating system for test
     inventory_event_message['type'] = 'updated'
     inventory_event_message['platform_metadata'] = None
     updated_display_name = 'Test - Display Name Update'  # Test case change


### PR DESCRIPTION
### Changes:
1. Added conditions on for platform_metadata on update/create handler function
2. Converted db field parameters for get or create system handler to kwargs
3. Added logic for differentiation of log messages between Create and Update
4. Removed performance profile creation and utilization generator methods

### Reasons:
1. The processor should be able to handle `updated` msgs
2. Can be easily modified in case msg['type'] = created
3. Unleash the power of precise logs!
4. Please refer https://github.com/RedHatInsights/ros-backend/pull/138
   An attempt to avoid merge conflicts

### Additional:
- IMO we can merge this one post https://github.com/RedHatInsights/ros-backend/pull/138

