### PR TITLE
RHIROS-393 | io Utilization as dict and max_io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ insights-upload-data:
 		localhost:3000/api/ingress/v1/upload | python -m json.tool
 
 api-get-hosts:
-	curl -v -H "Content-Type: application/json"  -H "x-rh-identity: ${b64_identity}" localhost:8000/api/ros/v0/systems | python -m json.tool
+	curl -v -H "Content-Type: application/json" -H "x-rh-identity: ${b64_identity}" "localhost:8000/api/ros/v0/systems?order_by=max_io&order_how=DESC" | python -m json.tool

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -51,7 +51,7 @@ class HostsApi(Resource):
     performance_utilization_fields = {
         'cpu': fields.Integer,
         'memory': fields.Integer,
-        'max_io': fields.Float,
+        'max_io': fields.Integer,
         'io_all': fields.Raw
     }
     hosts_fields = {
@@ -211,7 +211,7 @@ class HostDetailsApi(Resource):
     performance_utilization_fields = {
         'cpu': fields.Integer,
         'memory': fields.Integer,
-        'max_io': fields.Float,
+        'max_io': fields.Integer,
         'io_all': fields.Raw
     }
     profile_fields = {
@@ -273,7 +273,7 @@ class HostHistoryApi(Resource):
         'cpu': fields.Integer,
         'memory': fields.Integer,
         'io_all': fields.Raw,
-        'max_io': fields.Float,
+        'max_io': fields.Integer,
         'report_date': fields.String
     }
     meta_fields = {

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -272,7 +272,8 @@ class HostHistoryApi(Resource):
     performance_utilization_fields = {
         'cpu': fields.Integer,
         'memory': fields.Integer,
-        'io': fields.Raw,
+        'io_all': fields.Raw,
+        'max_io': fields.Float,
         'report_date': fields.String
     }
     meta_fields = {
@@ -320,7 +321,7 @@ class HostHistoryApi(Resource):
 
         performance_history = []
         for profile in query_results:
-            performance_record = sort_io_dict(profile.performance_utilization, remove_io_dict=False)
+            performance_record = sort_io_dict(profile.performance_utilization)
             performance_record['report_date'] = profile.report_date
             performance_history.append(performance_record)
 

--- a/ros/api/v0/hosts.py
+++ b/ros/api/v0/hosts.py
@@ -6,7 +6,7 @@ from flask_restful import Resource, abort, fields, marshal_with
 from ros.lib.models import (
     PerformanceProfile, RhAccount, System,
     db, RecommendationRating)
-from ros.lib.utils import is_valid_uuid, identity, user_data_from_identity
+from ros.lib.utils import is_valid_uuid, identity, user_data_from_identity, sort_io_dict
 from ros.api.common.pagination import (
     build_paginated_system_list_response,
     limit_value,
@@ -51,7 +51,8 @@ class HostsApi(Resource):
     performance_utilization_fields = {
         'cpu': fields.Integer,
         'memory': fields.Integer,
-        'io': fields.Integer
+        'max_io': fields.Float,
+        'io_all': fields.Raw
     }
     hosts_fields = {
         'fqdn': fields.String,
@@ -129,7 +130,9 @@ class HostsApi(Resource):
                 system_dict = row.System.__dict__
                 host = {skey: system_dict[skey] for skey in SYSTEM_COLUMNS}
                 host['account'] = row.RhAccount.account
-                host['performance_utilization'] = row.PerformanceProfile.performance_utilization
+                host['performance_utilization'] = sort_io_dict(
+                    row.PerformanceProfile.performance_utilization
+                )
                 host['idling_time'] = row.PerformanceProfile.idling_time
                 host['io_wait'] = row.PerformanceProfile.io_wait
                 hosts.append(host)
@@ -185,7 +188,7 @@ class HostsApi(Resource):
             return (sort_order(System.display_name),
                     asc(PerformanceProfile.system_id),)
 
-        score_methods = ['cpu', 'memory', 'io']
+        score_methods = ['cpu', 'memory', 'max_io']
         if order_method in score_methods:
             return (
                 sort_order(PerformanceProfile.performance_utilization[
@@ -208,7 +211,8 @@ class HostDetailsApi(Resource):
     performance_utilization_fields = {
         'cpu': fields.Integer,
         'memory': fields.Integer,
-        'io': fields.Integer
+        'max_io': fields.Float,
+        'io_all': fields.Raw
     }
     profile_fields = {
         'fqdn': fields.String,
@@ -252,7 +256,7 @@ class HostDetailsApi(Resource):
         record = None
         if profile:
             record = {key: system.__dict__[key] for key in SYSTEM_COLUMNS}
-            record['performance_utilization'] = profile.performance_utilization
+            record['performance_utilization'] = sort_io_dict(profile.performance_utilization)
             record['rating'] = rating_record.rating if rating_record else None
             record['report_date'] = profile.report_date
             record['idling_time'] = profile.idling_time
@@ -268,7 +272,7 @@ class HostHistoryApi(Resource):
     performance_utilization_fields = {
         'cpu': fields.Integer,
         'memory': fields.Integer,
-        'io': fields.Integer,
+        'io': fields.Raw,
         'report_date': fields.String
     }
     meta_fields = {
@@ -316,7 +320,7 @@ class HostHistoryApi(Resource):
 
         performance_history = []
         for profile in query_results:
-            performance_record = profile.performance_utilization
+            performance_record = sort_io_dict(profile.performance_utilization, remove_io_dict=False)
             performance_record['report_date'] = profile.report_date
             performance_history.append(performance_record)
 

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -5,7 +5,6 @@ from flask import jsonify, make_response
 from flask_restful import abort
 
 
-
 def is_valid_uuid(val):
     try:
         uuid.UUID(str(val), version=4)

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -88,3 +88,17 @@ def convert_iops_from_percentage(iops_dict):
     for key, value in iops_dict.items():
         iops_in_mbps[key] = float(value) * 100
     return iops_in_mbps
+
+
+def sort_io_dict(performance_utilization: dict, remove_io_dict: bool = True):
+    """
+    Sorts io dict by max_io in descending order.
+    """
+    io_dict = performance_utilization['io']
+    io_dict_key = 'io_all' if remove_io_dict is True else 'io'
+    del performance_utilization['io']
+    sorted_io_dict = {
+        io_dict_key: dict(sorted(io_dict.items(), key=lambda x: x[1], reverse=True))
+    }
+    performance_utilization.update({**sorted_io_dict})
+    return performance_utilization

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -3,7 +3,7 @@ import base64
 import json
 from flask import jsonify, make_response
 from flask_restful import abort
-import ast as type_evaluation
+
 
 
 def is_valid_uuid(val):

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -3,6 +3,7 @@ import base64
 import json
 from flask import jsonify, make_response
 from flask_restful import abort
+import ast as type_evaluation
 
 
 def is_valid_uuid(val):
@@ -89,15 +90,13 @@ def convert_iops_from_percentage(iops_dict):
     return iops_in_mbps
 
 
-def sort_io_dict(performance_utilization: dict, remove_io_dict: bool = True):
+def sort_io_dict(performance_utilization: dict):
     """
     Sorts io dict by max_io in descending order.
     """
-    io_dict = performance_utilization['io']
-    io_dict_key = 'io_all' if remove_io_dict is True else 'io'
-    del performance_utilization['io']
     sorted_io_dict = {
-        io_dict_key: dict(sorted(io_dict.items(), key=lambda x: x[1], reverse=True))
+        'io_all': dict(sorted(performance_utilization['io'].items(), key=lambda x: x[1], reverse=True))
     }
     performance_utilization.update({**sorted_io_dict})
+    del performance_utilization['io']
     return performance_utilization

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -337,8 +337,11 @@
                             "cpu": {
                                 "type": "number"
                             },
-                            "io": {
-                                "type": "number"
+                            "max_io": {
+                                "type": "integer"
+                            },
+                            "io_all": {
+                                "type": "object"
                             }
                         }
                     },
@@ -387,8 +390,11 @@
                             "cpu": {
                                 "type": "number"
                             },
-                            "io": {
-                                "type": "number"
+                            "max_io": {
+                                "type": "integer"
+                            },
+                            "io_all": {
+                                "type": "object"
                             }
                         }
                     },
@@ -445,8 +451,11 @@
                     "memory": {
                         "type": "integer"
                     },
-                    "io": {
+                    "max_io": {
                         "type": "integer"
+                    },
+                    "io_all": {
+                        "type": "object"
                     },
                     "report_date": {
                         "type": "string"


### PR DESCRIPTION
### Changes:
1. HostsApi modified marshall fields and added io dict sorting, max_io
2. HostDetailsApi modified marshall fields and added io dict sorting, max_io
   to keep it consistent with HostsApi
3. HostHistoryApi io values are now dict and sorted on values
4. max_io added to build_sort_expression for enabling ASC and DESC sorting
5. Added util function for sorting io_dict
6. Modified Make file for easier testing, can be reverted if deemed not necessary

### Sample Responses:

### All Systems:
 `/api/ros/v0/systems?order_by=max_io&order_how=DESC`

```
"data": [
        {
            "fqdn": "rhel8-test.hyrdvbbl3ugefmkdahnvv2bx1h.rx.internal.cloudapp.net",
            "display_name": "rhel8-test.hyrdvbbl3ugefmkdahnvv2bx1h.rx.internal.cloudapp.net",
            "inventory_id": "f73715ea-00b6-4a02-a4aa-528584b04dfd",
            "account": "0000001",
            "number_of_suggestions": 0,
            "state": "Optimized",
            "performance_utilization": {
                "cpu": 100,
                "memory": 95,
                "max_io": 700.0,
                "io_all": {
                    "xvdb": 700,
                    "xvdc": 92,
                    "xvda": 72
                }
            },
            "cloud_provider": "azure",
            "instance_type": "Standard_B1s",
            "idling_time": "98.90",
            "io_wait": null
        },
        {
            "fqdn": "ip-172-31-45-168.ap-south-1.compute.internal",
            "display_name": "ip-172-31-45-168.ap-south-1.compute.internal",
            "inventory_id": "f2b4c41d-27bd-4785-9dc4-ac09b6782981",
            "account": "0000001",
            "number_of_suggestions": 0,
            "state": "Optimized",
            "performance_utilization": {
                "cpu": 5,
                "memory": 22,
                "max_io": 400.0,
                "io_all": {
                    "sdb": 400,
                    "sda": 100,
                    "xvga": 95
                }
            },
            "cloud_provider": "aws",
            "instance_type": "t2.micro",
            "idling_time": "99.60",
            "io_wait": null
        },
        {
            "fqdn": "ip-172-31-25-176.ec2.internal",
            "display_name": "ip-172-31-25-176.ec2.internal",
            "inventory_id": "88f2588b-a1f1-4638-8b45-50ca2c3ec93e",
            "account": "0000001",
            "number_of_suggestions": 0,
            "state": "Waiting for data",
            "performance_utilization": {
                "cpu": 8,
                "memory": 27,
                "max_io": 352.0,
                "io_all": {
                    "sdb": 352,
                    "sda": 100,
                    "xvga": 75
                }
            },
            "cloud_provider": "aws",
            "instance_type": "t2.micro",
            "idling_time": null,
            "io_wait": null
        }
    ]

```

### Individual Endpoint: 
`/api/ros/v0/systems/88f2588b-a1f1-4638-8b45-50ca2c3ec93e`

```
{
    "fqdn": "ip-172-31-25-176.ec2.internal",
    "inventory_id": "88f2588b-a1f1-4638-8b45-50ca2c3ec93e",
    "display_name": "ip-172-31-25-176.ec2.internal",
    "performance_utilization": {
        "cpu": 8,
        "memory": 27,
        "max_io": 352,
        "io_all": {
            "sdb": 352,
            "sda": 100,
            "xvga": 75
        }
    },
    "rating": 0,
    "number_of_suggestions": 0,
    "state": "Waiting for data",
    "report_date": "2021-12-15",
    "instance_type": "t2.micro",
    "cloud_provider": "aws",
    "idling_time": null,
    "io_wait": null
}

```

### History Endpoint:

`api/ros/v0/systems/f2b4c41d-27bd-4785-9dc4-ac09b6782981/history`

```
"data": [
        {
            "cpu": 5,
            "memory": 22,
            "io": {
                "sdb": 400,
                "sda": 100,
                "xvga": 95
            },
            "report_date": "2021-12-16"
        },
        {
            "cpu": 5,
            "memory": 22,
            "io": {
                "sdb": 400,
                "sda": 100,
                "xvga": 95
            },
            "report_date": "2021-12-15"
        }
    ]

```