### PR TITLE
Refs RHIROS 133 - fix type error for metrics port

### DIFF
--- a/ros/processor/main.py
+++ b/ros/processor/main.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     events.start()
     engine_results.start()
     collector.start()
-    start_http_server(METRICS_PORT)
+    start_http_server(int(METRICS_PORT))
     # Wait for threads to finish
     events.join()
     engine_results.join()


### PR DESCRIPTION
As metrics port value set as string in template, currently it is failing while restarting http server. 
To fix this, converting metrics port value to integer before passing as argument.