### PR TITLE
RHIROS-449 Get region from performance_record

### DIFF
--- a/ros/processor/insights_engine_result_consumer.py
+++ b/ros/processor/insights_engine_result_consumer.py
@@ -130,7 +130,7 @@ class InsightsEngineResultConsumer:
                     number_of_recommendations=rec_count,
                     state=SYSTEM_STATES[state_key],
                     instance_type=performance_record.get('instance_type'),
-                    region=reports[0].get('details').get('region')
+                    region=performance_record.get('region')
                 )
                 LOG.info(
                     f"{self.prefix} - System created/updated successfully: {host['id']}"
@@ -159,7 +159,8 @@ class InsightsEngineResultConsumer:
                         'max_io': 0,
                         'io': {}
                     }
-
+                del performance_record['instance_type']
+                del performance_record['region']
                 get_or_create(
                     db.session, PerformanceProfile, ['system_id', 'report_date'],
                     system_id=system.id,

--- a/ros/processor/insights_engine_result_consumer.py
+++ b/ros/processor/insights_engine_result_consumer.py
@@ -159,8 +159,10 @@ class InsightsEngineResultConsumer:
                         'max_io': 0,
                         'io': {}
                     }
+                # Following are saved on respective system record
                 del performance_record['instance_type']
                 del performance_record['region']
+
                 get_or_create(
                     db.session, PerformanceProfile, ['system_id', 'report_date'],
                     system_id=system.id,

--- a/ros/processor/process_archive.py
+++ b/ros/processor/process_archive.py
@@ -46,10 +46,12 @@ def performance_profile(lscpu, aws_instance_id, azure_instance_type, pmlog_summa
     profile["total_cpus"] = int(lscpu.info.get('CPUs'))
     if aws_instance_id:
         profile["instance_type"] = aws_instance_id.get('instanceType')
+        profile["region"] = aws_instance_id.get('region')
     elif azure_instance_type:
         profile["instance_type"] = azure_instance_type.raw
     else:
         profile["instance_type"] = None
+        profile["region"] = None
 
     metadata_response = make_metadata()
     metadata_response.update(profile)

--- a/sample-files/insights-engine-result-idle.json
+++ b/sample-files/insights-engine-result-idle.json
@@ -1,0 +1,8431 @@
+{
+    "input": {
+      "platform_metadata": {
+        "account": "0000001",
+        "b64_identity": "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMSIsInR5cGUiOiAiVXNlciIsInVzZXIiOiB7InVzZXJuYW1lIjogInR1c2VyQHJlZGhhdC5jb20iLCJlbWFpbCI6ICJ0dXNlckByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6ICJ0ZXN0IiwibGFzdF9uYW1lIjogInVzZXIiLCJpc19hY3RpdmUiOiB0cnVlLCJpc19vcmdfYWRtaW4iOiBmYWxzZSwgImlzX2ludGVybmFsIjogdHJ1ZSwgImxvY2FsZSI6ICJlbl9VUyJ9LCJpbnRlcm5hbCI6IHsgIm9yZ19pZCI6ICIwMDAwMDEifX19Cg==",
+        "category": "collection",
+        "elapsed_time": 1640868877.4340131,
+        "extras": {},
+        "host": {},
+        "id": null,
+        "metadata": {
+          "reporter": "",
+          "stale_timestamp": "0001-01-01T00:00:00Z"
+        },
+        "payload_id": null,
+        "principal": "000001",
+        "request_id": "7bc5e4526e8b/iSA5PcbSgL-000002",
+        "satellite_managed": null,
+        "service": "advisor",
+        "size": 2549760,
+        "timestamp": "2021-12-30T12:54:36.431033461Z",
+        "url": "http://minio:9000/insights-upload-perma/7bc5e4526e8b/iSA5PcbSgL-000002?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211230%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211230T125436Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=4a7238fb0dd8e69018a78693a36412cabc76fb18811d632c6a014fa96e276f8e",
+        "validation": null,
+        "test": null,
+        "is_ros": "true"
+      },
+      "metadata": {
+        "request_id": "7bc5e4526e8b/iSA5PcbSgL-000002"
+      },
+      "host": {
+        "mac_addresses": [
+          "0a:94:1d:36:ff:21",
+          "00:00:00:00:00:00"
+        ],
+        "account": "0000001",
+        "per_reporter_staleness": {
+          "puptoo": {
+            "last_check_in": "2021-12-30T12:54:38.856070+00:00",
+            "stale_timestamp": "2021-12-31T17:54:38.752992+00:00",
+            "check_in_succeeded": true
+          }
+        },
+        "created": "2021-12-30T12:54:17.362760+00:00",
+        "updated": "2021-12-30T12:54:38.856542+00:00",
+        "system_profile": {
+          "os_release": "8.4",
+          "os_kernel_version": "4.18.0",
+          "satellite_managed": false
+        },
+        "ip_addresses": [
+          "172.31.28.69"
+        ],
+        "ansible_host": null,
+        "subscription_manager_id": "4b1efbbe-a447-48d0-98c3-3594aae1d2c5",
+        "reporter": "puptoo",
+        "culled_timestamp": "2022-01-14T17:54:38.752992+00:00",
+        "stale_warning_timestamp": "2022-01-07T17:54:38.752992+00:00",
+        "bios_uuid": "ec2c79ab-02ff-d09b-31a9-583a902dd74b",
+        "satellite_id": null,
+        "id": "f6493432-0688-4575-8759-fca630e26608",
+        "provider_id": null,
+        "display_name": "ip-172-31-28-69.ec2.internal",
+        "provider_type": null,
+        "fqdn": "ip-172-31-28-69.ec2.internal",
+        "insights_id": "a319580a-2321-47c7-b061-886548bea067",
+        "stale_timestamp": "2021-12-31T17:54:38.752992+00:00",
+        "tags": []
+      },
+      "type": "updated",
+      "timestamp": "2021-12-30T12:54:38.873989+00:00"
+    },
+    "results": {
+      "system": {
+        "metadata": {
+          "timezone_information": {
+            "utcoffset": 0,
+            "timezone": "UTC"
+          },
+          "rhel_version": "8.4",
+          "bios_information": {
+            "bios_revision": "4.2",
+            "release_date": "08/24/2006",
+            "vendor": "Xen",
+            "version": "4.2.amazon"
+          },
+          "system_information": {
+            "product_name": "HVM domU",
+            "family": "Not Specified",
+            "manufacturer": "Xen",
+            "virtual_machine": true
+          },
+          "cpu_utilization": "0",
+          "mem_utilization": "0",
+          "io_utilization": {
+            "xvda": "0.314"
+          },
+          "release": "Red Hat Enterprise Linux release 8.4 (Ootpa)"
+        },
+        "hostname": "ip-172-31-28-69.ec2.internal",
+        "remote_branch": -1,
+        "remote_leaf": -1,
+        "system_id": "a319580a-2321-47c7-b061-886548bea067",
+        "product": "rhel",
+        "type": "host"
+      },
+      "reports": [
+        {
+          "rule_id": "insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+          "component": "telemetry.rules.plugins.other.insights_core_egg_not_up2date.report",
+          "type": "rule",
+          "key": "INSIGHTS_CORE_EGG_NOT_UP2DATE",
+          "details": {
+            "rhel": "8.4",
+            "cur": "3.0.251-1",
+            "rel": "3.0.255",
+            "type": "rule",
+            "error_key": "INSIGHTS_CORE_EGG_NOT_UP2DATE"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4587"
+            ],
+            "kcs": [
+              "https://access.redhat.com/articles/3747741"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "rule_id": "CVE_2021_33909_kernel|CVE_2021_33909",
+          "component": "prodsec.rules.CVE_2021_33909_kernel.report",
+          "type": "rule",
+          "key": "CVE_2021_33909",
+          "details": {
+            "kernel_package_name": "kernel",
+            "running_kernel": "4.18.0-305.el8",
+            "cves": {
+              "CVE-2021-33909": false
+            },
+            "type": "rule",
+            "error_key": "CVE_2021_33909"
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/CVE-2021-33909"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "rule_id": "xen_kdump_supported|XEN_KDUMP_SUPPORTED_V1",
+          "component": "telemetry.rules.plugins.aws.xen_kdump_supported.report",
+          "type": "rule",
+          "key": "XEN_KDUMP_SUPPORTED_V1",
+          "details": {
+            "rhel_version": "8.4",
+            "type": "rule",
+            "error_key": "XEN_KDUMP_SUPPORTED_V1"
+          },
+          "tags": [
+            "xen",
+            "rhel8",
+            "aws",
+            "rhel7",
+            "rhel6"
+          ],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2890881"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3484",
+              "https://projects.engineering.redhat.com/browse/CEECBA-4123",
+              "https://issues.redhat.com/browse/CEECBA-5304"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1859233",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1954906"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "rule_id": "CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2",
+          "component": "prodsec.rules.CVE_2018_3639_cpu_kernel.report",
+          "type": "rule",
+          "key": "CVE_2018_3639_CPU_BAD_MICROCODE_2",
+          "details": {
+            "vuln_file_present": true,
+            "cmd_avail": true,
+            "running_kernel": "4.18.0-305.el8.x86_64",
+            "rt": false,
+            "cloud_provider": "Amazon Web Services",
+            "virtualization": "xen",
+            "cves": {
+              "CVE-2018-3639": false
+            },
+            "type": "rule",
+            "error_key": "CVE_2018_3639_CPU_BAD_MICROCODE_2"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/ssbd"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1566890"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "rule_id": "ntp_leapsmear|NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+          "component": "telemetry.rules.plugins.service.ntp_leapsmear.report",
+          "type": "rule",
+          "key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+          "details": {
+            "smearing_servers": [
+              "169.254.169.123"
+            ],
+            "smearing_patterns_len": 1,
+            "nonsmearing_servers": [
+              "2.rhel.pool.ntp.org"
+            ],
+            "leap_directives": [
+              "leapsectz right/UTC"
+            ],
+            "is_special_aws_ip_case": true,
+            "service": "chrony",
+            "type": "rule",
+            "error_key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/5132071"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3662",
+              "https://projects.engineering.redhat.com/browse/CEECBA-4130"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "rule_id": "CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+          "component": "prodsec.rules.CVE_2018_12130_cpu_kernel.report",
+          "type": "rule",
+          "key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+          "details": {
+            "rel": 8,
+            "vuln": [
+              "Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown"
+            ],
+            "rt": false,
+            "cmd_any": false,
+            "cmdline_raw": "BOOT_IMAGE=(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64 root=UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585 ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+            "cmdline_dict": {
+              "BOOT_IMAGE": [
+                "(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64"
+              ],
+              "root": [
+                "UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585"
+              ],
+              "ro": [
+                true
+              ],
+              "console": [
+                "ttyS0,115200n8",
+                "tty0"
+              ],
+              "net.ifnames": [
+                "0"
+              ],
+              "rd.blacklist": [
+                "nouveau"
+              ],
+              "nvme_core.io_timeout": [
+                "4294967295"
+              ],
+              "crashkernel": [
+                "auto"
+              ]
+            },
+            "rh6nosmt": false,
+            "rh6nosmt1st": false,
+            "dmesg_wrapped": false,
+            "cloud_provider": "Amazon Web Services",
+            "virtualization": "xen",
+            "cves": {
+              "CVE-2018-12126": false,
+              "CVE-2018-12130": false,
+              "CVE-2018-12127": false,
+              "CVE-2019-11091": false
+            },
+            "type": "rule",
+            "error_key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/mds"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1646784"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "rule_id": "product_eol_check|AE_EOL_ERROR",
+          "component": "telemetry.rules.plugins.other.product_eol_check.report_ae",
+          "type": "rule",
+          "key": "AE_EOL_ERROR",
+          "details": {
+            "product": [
+              {
+                "name": "Ansible Engine",
+                "version": "2.8",
+                "phase": "End of Life",
+                "eol": "2021-01-21",
+                "days": 344,
+                "policy": "https://access.redhat.com/support/policy/updates/ansible-engine"
+              }
+            ],
+            "brief": {
+              "Ansible Engine": "https://access.redhat.com/support/policy/updates/ansible-engine"
+            },
+            "type": "rule",
+            "error_key": "AE_EOL_ERROR"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-3825"
+            ],
+            "product_documentation": [
+              "https://access.redhat.com/product-life-cycles",
+              "https://access.redhat.com/support/policy/update_policies"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "rule_id": "ros_instance_evaluation|INSTANCE_IDLE",
+          "component": "telemetry.rules.plugins.ros.ros_instance_evaluation.report",
+          "type": "rule",
+          "key": "INSTANCE_IDLE",
+          "details": {
+            "rhel": "8.4",
+            "cloud_provider": "Amazon Web Services",
+            "instance_type": "t2.micro",
+            "region": "us-east-1",
+            "price": 0.0116,
+            "candidates": [
+              [
+                "t2.nano",
+                0.0058
+              ]
+            ],
+            "summary": [
+              "System is IDLE"
+            ],
+            "type": "rule",
+            "error_key": "INSTANCE_IDLE"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5875"
+            ],
+            "kcs": []
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        }
+      ],
+      "fingerprints": [],
+      "none": [
+        {
+          "none_id": "network_vmxnet3_dropped_udp|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vmxnet3_dropped_udp.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/67823"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_grub|NONE_KEY",
+          "component": "prodsec.rules.hardening_grub.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_randomized_vm|NONE_KEY",
+          "component": "prodsec.rules.hardening_randomized_vm.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/44460"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_fstab|NONE_KEY",
+          "component": "prodsec.rules.hardening_fstab.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/430253"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_max_uid|NONE_KEY",
+          "component": "prodsec.rules.hardening_max_uid.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/25404"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_browser_not_root|NONE_KEY",
+          "component": "prodsec.rules.hardening_browser_not_root.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/2094931"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_logging_audit_max_log|NONE_KEY",
+          "component": "prodsec.rules.hardening_logging_audit_max_log.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_bridge_multicast_fail|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_bridge_multicast_fail.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/361063",
+              "https://access.redhat.com/solutions/784373"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1090670",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1090749"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rport_delete_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.rport_delete_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1289833"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "net_source_routing_enabled|NONE_KEY",
+          "component": "prodsec.rules.net_source_routing_enabled.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/389853"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_hang_hp_bl460c_g7|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_hang_hp_bl460c_g7.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/257323"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "audit_backlog_limit_exceeded_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.service.audit_backlog_limit_exceeded_panic.retport",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/44602"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_hpasr|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_hpasr.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/501543"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "qla2xxx_request_stuck|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.qla2xxx_request_stuck.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/189633"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_multiple_lo_ip_addr|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_multiple_lo_ip_addr.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2111561"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_nfs_stuck_syn_burst|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_nfs_stuck_syn_burst.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3018371"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "alias_interface_invalid|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.alias_interface_invalid.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/21204"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "incorrect_process_utimes|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.incorrect_process_utimes.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/185843"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nfs4_client_hang|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.nfs4_client_hang.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2162441",
+              "https://access.redhat.com/solutions/2685641"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "min_free_kbytes|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.min_free_kbytes.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-249",
+              "https://projects.engineering.redhat.com/browse/CEECBA-3241"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/336033"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "disabled_monitoring_bond|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.bonding.disabled_monitoring_bond.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/172483"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-320"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "intel5500_interrupt_remapping_failure|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.intel5500_interrupt_remapping_failure.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-126"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/110053"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=887006"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ip_fragment_packet_drop|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.ip_fragment_packet_drop.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1498603"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "bnx2fc_scan_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.bnx2fc_scan_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/node/893403"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "systemd_open_watchdog_nmi|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.systemd_open_watchdog_nmi.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1309033"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "tsc_rhel612_hung|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.tsc_rhel612_hung.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/60365"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "tsc_xeon_reboot_uptime|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.tsc_xeon_reboot_uptime.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/433883"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vfs_cache_pressure|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.vfs_cache_pressure.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/16995"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vm_min_free_kbytes_zero|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.vm_min_free_kbytes_zero.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1727288"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2676"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "tcp_tw_race|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.tcp_tw_race.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1390823"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_yum|NONE_KEY",
+          "component": "prodsec.rules.hardening_yum.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nfs_mount_unresponsive_with_disabled_tcp_timestamps|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.nfs_mount_unresponsive_with_disabled_tcp_timestamps.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2338"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3060231"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1459978",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1472128",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1479043"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_610_vxdmp_powerpath|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.kernel_panic_610_vxdmp_powerpath.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3676431"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "storage_mlx5_srp_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.storage_mlx5_srp_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2189191"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_selinux_policy|NONE_KEY",
+          "component": "prodsec.rules.hardening_selinux_policy.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "selinux_disabled_kernel_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.other.selinux_disabled_kernel_panic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/4890471"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4701",
+              "https://issues.redhat.com/browse/CEECBA-4962",
+              "https://issues.redhat.com/browse/CEECBA-5240"
+            ],
+            "product_documentation": [
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.1_release_notes/rhel-8_1_0_release#known-issue_security"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1778990"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "numa_perf_regression|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.numa_perf_regression.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/802693"
+            ],
+            "jira": []
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cifs_share_lost|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.cifs_share_lost.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/713373"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cifs_find_writable_file_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.cifs_find_writable_file_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2735"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2110301"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1295008",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1577086"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hp_ilo4_nmi|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.hp_ilo4_nmi.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/707563"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "resolv_conf_over_three|NONE_KEY",
+          "component": "telemetry.rules.plugins.service.resolv_conf_over_three.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/6407"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_gpg_pubkey|NONE_KEY",
+          "component": "prodsec.rules.hardening_gpg_pubkey.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cifs_null_pointer_dereference|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.cifs_null_pointer_dereference.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3485421"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1591092",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1609159"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vxfs_mount_fail_selinux_policy|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.vxfs_mount_fail_selinux_policy.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3168651",
+              "https://access.redhat.com/solutions/3886991"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_need_bonding_parameter|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_need_bonding_parameter.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/69510"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rx_crc_errors|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.rx_crc_errors.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/153413",
+              "https://access.redhat.com/solutions/154543"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_firewall_zone_removed|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_firewall_zone_removed.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2770321"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_iptables_services_fails|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_iptables_services_fails.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3138851"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_hpsa_driver_phy_disk_pointer_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_hpsa_driver_phy_disk_pointer_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3485"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2112491"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1334773",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1334396",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1335411",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1334260"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_tab_key|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_tab_key.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/195653"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "leap_smear_chronyd_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.leap_smear_chronyd_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2759021"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rhnsd_pid_world_write|NONE_KEY",
+          "component": "telemetry.rules.plugins.sysmgmt.registration.rhnsd_pid_world_write.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3220971"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1480306"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_ipv6_dev_route_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_ipv6_dev_route_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2716"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4209461"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "leapsec_system_hard_hang|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.leapsec_system_hard_hang.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/154713",
+              "https://access.redhat.com/solutions/154793"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_hang_hp_gen9|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_hang_hp_gen9.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2797041"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "load_nfsmod_failed|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.load_nfsmod_failed.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4984"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2314491"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vlan_mtu_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vlan_mtu_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2162"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2888911"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1414186",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1439166"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "subscription_cacert_expiration|NONE_KEY",
+          "component": "telemetry.rules.plugins.sysmgmt.registration.subscription_cacert_expiration.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3261461"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4841"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_manager_custom_mtu_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_manager_custom_mtu_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2195741"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1303968"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "fs_resize2fs_bug|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.fs_resize2fs_bug.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-730",
+              "https://issues.redhat.com/browse/CEECBA-4984"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/173543"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_bnx2x_firmware_rt_kernel|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_bnx2x_firmware_rt_kernel.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2987451"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hpsa_task_blocked|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.hpsa_task_blocked.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1179703"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hugepage_over_reserved|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.hugepage_over_reserved.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2116991"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "pcp_logger_network_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.pcp.pcp_logger_network_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4865"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5394191"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1875659",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1854035"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "slow_performance_bgrt_mapping|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.slow_performance_bgrt_mapping.retport",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3802481"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1481667"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hugepage_race_condition_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.hugepage_race_condition_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1992703"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vlan_interface_gateway|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.vlan_interface_gateway.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2171881"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1309899"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "splunkd_memory_corruption|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.splunkd_memory_corruption.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1382833"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ibm_power_broken_topology|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.ibm_power_broken_topology.retport",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3669101"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1620038"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "stack_corrupted_using_xfs|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.stack_corrupted_using_xfs.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/54544"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_initscripts_slave_config_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.bonding.network_initscripts_slave_config_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2952041"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1428574"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "sanity_check_fstab|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.sanity_check_fstab.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/23769",
+              "https://access.redhat.com/solutions/3109581"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3961"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ilo|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.ilo.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/744973"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "missing_grub_symlink|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.missing_grub_symlink.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/770663"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "mce_logs_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.mce_logs_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3160241"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "gfs_mount_option_lock_nolock_is_unsupported|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.gfs_mount_option_lock_nolock_is_unsupported.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2255"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2592671"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "infiniband_rdma_data_corruption|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.infiniband_rdma_data_corruption.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4540"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1872424",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1856158"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "start_lldpad_fcoe_cause_kernel_hang|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.start_lldpad_fcoe_cause_kernel_hang.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "http://access.redhat.com/solutions/3683051"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2470"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1353659",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1656143",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1656720"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "glibc_nssdb_miss_i686|NONE_KEY",
+          "component": "telemetry.rules.plugins.tools.glibc_nssdb_miss_i686.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1807824"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3654"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "neutron_openvswitch_agent_fail_with_ryu_key_error|NONE_KEY",
+          "component": "telemetry.rules.plugins.osp.neutron_openvswitch_agent_fail_with_ryu_key_error.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3128111"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "udev_bug|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.udev_bug.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2592401"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nmi_switch_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.nmi_switch_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/265173"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "no_ept_panic_with_l1tf|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.no_ept_panic_with_l1tf.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3570921"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ifdown_alias_interface|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.ifdown_alias_interface.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2099351"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "multipathd_start_failed|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.multipathd_start_failed.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1394763"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4984"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "storage_fnic_storage_offline|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.storage_fnic_storage_offline.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2162451"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4212"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nic_rx_perf_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.nic_rx_perf_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/20278"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "intel_purley_skylake_supportable|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.intel_purley_skylake_supportable.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3135591"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "idm_smbv1_windows_unsupport|NONE_KEY",
+          "component": "telemetry.rules.plugins.idm.idm_smbv1_windows_unsupport.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3164551"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1196140"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_ipaddr_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_ipaddr_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2785051"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1394500"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "storage_iscsi_without_netdev|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.storage_iscsi_without_netdev.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3889"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_slow_tcp_frto_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_slow_tcp_frto_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3658"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4978771"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1821522",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1694860",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1257096"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cciss_removed_on_rhel7|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.cciss_removed_on_rhel7.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/874443"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nic_speed_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.nic_speed_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/111173"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-667",
+              "https://issues.redhat.com/browse/CEECBA-5474"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "be2net_generate_pause_frames|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.be2net_generate_pause_frames.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/349783"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ovirt_node_upgrade_failure_if_selinux_is_disabled|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.ovirt_node_upgrade_failure_if_selinux_is_disabled.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "http://access.redhat.com/solutions/3346371"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1519784",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1542833"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_manager_arp_ip_address_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.bonding.network_manager_arp_ip_address_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3952491"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1678796",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1683092"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cpu_max_frequency_not_maitained|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.cpu_max_frequency_not_maitained.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2836"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2895271"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nic_start_failed_at_boot|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.nic_start_failed_at_boot.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2523931"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "crash_in_memmap_init_zone|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.crash_in_memmap_init_zone.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3208581"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "thp_defrag_performance|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.thp_defrag_performance.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/280443"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_manager_team_mac_address_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.bonding.network_manager_team_mac_address_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2158"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3372231"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1569924"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "docker_deferred_remove|NONE_KEY",
+          "component": "telemetry.rules.plugins.container.docker_deferred_remove.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4984"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2517781"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "tsc_reboot_uptime|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.tsc_reboot_uptime.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/68466"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rhev_host_certificates_expiration|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.rhev_host_certificates_expiration.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2985561"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ceph_kernel_client_append_write_bug|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.ceph_kernel_client_append_write_bug.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2329"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4254821"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1691227",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1696594",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1696595"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "megaraid_scsi_timeout_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.megaraid_scsi_timeout_panic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-1787"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/337313"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "docker_icc_false|NONE_KEY",
+          "component": "telemetry.rules.plugins.container.docker_icc_false.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2619411"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "crashkernel_with_3w_modules|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.crashkernel_with_3w_modules.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2335111"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "docker_journald_stop|NONE_KEY",
+          "component": "telemetry.rules.plugins.container.docker_journald_stop.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2533421"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rename_network_interface|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.rename_network_interface.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1446773"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ocp_monitor_separate_disk|NONE_KEY",
+          "component": "telemetry.rules.plugins.shift.ocp_monitor_separate_disk.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3428961"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5276"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "python_symlink_misconfiguration|NONE_KEY",
+          "component": "telemetry.rules.plugins.service.python_symlink_misconfiguration.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-3797"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1779294"
+            ],
+            "product_documentation": [
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#python_versions",
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#configuring-the-unversioned-python_installing-and-using-python"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_logging_auditd|NONE_KEY",
+          "component": "prodsec.rules.hardening_logging_auditd.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "dsa_filter_consumes_slab_objects|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.dsa_filter_consumes_slab_objects.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/4518431"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2968"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nfs_with_fscache_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.nfs_with_fscache_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2431"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2328681",
+              "https://access.redhat.com/solutions/2439131"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "find_busiest_group_div_0|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.find_busiest_group_div_0.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/58609"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_with_hardened_usercopy_due_to_splxmod|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_with_hardened_usercopy_due_to_splxmod.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3441"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3959371"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_logging_log_perms|NONE_KEY",
+          "component": "prodsec.rules.hardening_logging_log_perms.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nofile_set_to_unlimited_not_permitted|NONE_KEY",
+          "component": "telemetry.rules.plugins.shells.nofile_set_to_unlimited_not_permitted.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/33993"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-4146"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "idm_ipa_server_openjdk_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.idm.idm_ipa_server_openjdk_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4575"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5527751",
+              "https://access.redhat.com/solutions/5529501"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1892216"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vm_swappiness_oom|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.vm_swappiness_oom.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1149413"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ocp_ntp_not_enabled|NONE_KEY",
+          "component": "telemetry.rules.plugins.shift.ocp_ntp_not_enabled.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "product_documentation": [
+              "https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-ntp-synchronization"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5276"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_stuck_uio_bug|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_stuck_uio_bug.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5487"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1952952"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nfs_mount_option_override_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.nfs_mount_option_override_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3547051"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1594707"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "freeipmi_reboot|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.freeipmi_reboot.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/628963"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vpd_access_disabled|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.vpd_access_disabled.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3077141"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kpatch_induces_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kpatch_induces_panic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1845356"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3970"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "greenplum_database_hung|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.greenplum_database_hung.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2379961"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "idm_ipv6_disabled|NONE_KEY",
+          "component": "telemetry.rules.plugins.idm.idm_ipv6_disabled.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3149991"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rebuild_initrd_failed|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.rebuild_initrd_failed.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/129173"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "systemd_system_would_hang_in_shutting_down|NONE_KEY",
+          "component": "telemetry.rules.plugins.service.systemd_system_would_hang_in_shutting_down.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2277"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3181191"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1571098"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_nfs|NONE_KEY",
+          "component": "prodsec.rules.hardening_nfs.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_at_d_real|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_at_d_real.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2537"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3248571"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vpd_rw_failed|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.vpd_rw_failed.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/39748",
+              "https://access.redhat.com/solutions/633553"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "systemz_kdump_fail_with_devnode|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.systemz_kdump_fail_with_devnode.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/526113"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_nfs_user_mountable|NONE_KEY",
+          "component": "prodsec.rules.hardening_nfs_user_mountable.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rhev_manager_certificates_expiration|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.rhev_manager_certificates_expiration.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2985561"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_max_tries|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_max_tries.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_protocol|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_protocol.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "irqbalance_invalid_parsing|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.irqbalance_invalid_parsing.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2842141"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1393539"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_startups|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_startups.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_manager_dhcp_client_network_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_manager_dhcp_client_network_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4475"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5188461"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1843357"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rhv_network_setup_failure_if_empty_line_in_ifcfg_files|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.rhv_network_setup_failure_if_empty_line_in_ifcfg_files.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2823131"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1406651"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "irqbalance_not_balancing|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.irqbalance_not_balancing.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/677073"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=987801"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vm_io_scheduler|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.vm_io_scheduler.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/5427"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_root_login|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_root_login.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ipa_client_short_hostname|NONE_KEY",
+          "component": "telemetry.rules.plugins.idm.ipa_client_short_hostname.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/200673"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3655"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_manager_restart_fails_static_route|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_manager_restart_fails_static_route.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2215901"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1302532"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rhev_vm_using_legacy_usb_devices|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.rhev_vm_using_legacy_usb_devices.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3054491"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1443078"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_hugepages_allocation_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_hugepages_allocation_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/869233"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4247",
+              "https://issues.redhat.com/browse/CEECBA-4566"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "isdn_hangup_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.isdn_hangup_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2374511"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ansible_deprecated_repo|NONE_KEY",
+          "component": "telemetry.rules.plugins.other.ansible_deprecated_repo.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3359651"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1567750"
+            ],
+            "jira": []
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "btrfs_unsupported_rhel8|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.btrfs_unsupported_rhel8.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/197643"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1533904"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "pcc_cpufreq_driver_performance_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.pcc_cpufreq_driver_performance_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3804"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4379881",
+              "https://access.redhat.com/solutions/3393161"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rhevm_not_able_to_clone_vm_snapshot|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.rhevm_not_able_to_clone_vm_snapshot.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3205991"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1498478"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ocp_swap_on|NONE_KEY",
+          "component": "telemetry.rules.plugins.shift.ocp_swap_on.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3242331"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5276"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "dnf_install_update_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.other.dnf_install_update_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3898"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1832869"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ocp_sysctl_ipforward|NONE_KEY",
+          "component": "telemetry.rules.plugins.shift.ocp_sysctl_ipforward.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3586371"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5276"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nproc_common_entries|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.nproc_common_entries.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/146233"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_bond1_not_working|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_bond1_not_working.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/262043"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_hpsa|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_hpsa.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/44870"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=698268",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=715397"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_device_unregister_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_device_unregister_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3177471"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "numa_node_mapping_255_cpus|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.numa_node_mapping_255_cpus.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1571393"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_hpwdt_rhvh_sys_reset|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_hpwdt_rhvh_sys_reset.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3338821"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1491303"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3547"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_radix_tree_lookup_s390x|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_radix_tree_lookup_s390x.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2992"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4370121"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1725396"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_dhcp_connection_loss_nm_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_dhcp_connection_loss_nm_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2144"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/1614093"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vmw_driver_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.vmware.vmw_driver_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/639963"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-715"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vmware_guest_clock_unstable|NONE_KEY",
+          "component": "telemetry.rules.plugins.vmware.vmware_guest_clock_unstable.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3215651"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rsyslog_memory_leak|NONE_KEY",
+          "component": "telemetry.rules.plugins.other.rsyslog_memory_leak.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/4502651"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3499"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1714094"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_kptr_restrict_value|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_kptr_restrict_value.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2634"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1704572"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "vmware_slabinfo_nmi_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.vmware.vmware_slabinfo_nmi_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/23884"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-907"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_large_lun_config|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_large_lun_config.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/node/1382643",
+              "https://access.redhat.com/node/1480173"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1160104"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "wrong_cores_after_offline|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.wrong_cores_after_offline.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3468711"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_client_alive|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_client_alive.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ocp_tuned_regression|NONE_KEY",
+          "component": "telemetry.rules.plugins.shift.ocp_tuned_regression.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2688",
+              "https://issues.redhat.com/browse/CEECBA-5276"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4395931"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1739418"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_smbv1_server|NONE_KEY",
+          "component": "prodsec.rules.hardening_smbv1_server.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3164551"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1196140"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_nfs_world_access|NONE_KEY",
+          "component": "prodsec.rules.hardening_nfs_world_access.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3069421"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hp_gen8_gen9_kvm_vm_not_start|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.hp_gen8_gen9_kvm_vm_not_start.retport",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3373571"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "pcc_cpufreq_fail_to_load|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.pcc_cpufreq_fail_to_load.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2546"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3421421"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_config_perms|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_config_perms.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_log_buf_len_consume|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_log_buf_len_consume.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1769173"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3041"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "df_hangs_inconsistent_data_mtab|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.df_hangs_inconsistent_data_mtab.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3047"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3111191"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_empty_passwords|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_empty_passwords.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "df_used_negative|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.df_used_negative.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/17835"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_grace_time|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_grace_time.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "pacemaker_corosync_service_status|NONE_KEY",
+          "component": "telemetry.rules.plugins.clusterha.pacemaker_corosync_service_status.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/905823"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_dnssec_2|NONE_KEY",
+          "component": "prodsec.rules.hardening_dnssec_2.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/54644"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "leapp_upgrade_initramfs_missing|NONE_KEY",
+          "component": "telemetry.rules.plugins.leapp.leapp_upgrade_initramfs_missing.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5310"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/6004981"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "aio_max_nr_limit_reached|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.aio_max_nr_limit_reached.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/479623"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_flash|NONE_KEY",
+          "component": "prodsec.rules.hardening_flash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3756821"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "qlcnic_old_firmware|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.qlcnic_old_firmware.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1287363"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cifs_mount_ver_issue_in_fstab|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.cifs_mount_ver_issue_in_fstab.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3692491"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1650148",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1657841"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_smbv1_client|NONE_KEY",
+          "component": "prodsec.rules.hardening_smbv1_client.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3164551"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1196140"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "race_in_kernel_sched_task_group|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.race_in_kernel_sched_task_group.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3085"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4621451"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ipmi_list_corruption_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.ipmi_list_corruption_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2690791"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cloud_init_local_service_delays_reboot|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.cloud_init_local_service_delays_reboot.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3736",
+              "https://projects.engineering.redhat.com/browse/CEECBA-4119"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1625874"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "oracle_tuned_profiles_oracle|NONE_KEY",
+          "component": "telemetry.rules.plugins.oracle.oracle_tuned_profiles_oracle.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1196298",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1447323"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3753"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2867881"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_nfs_hostname_bnx2|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_nfs_hostname_bnx2.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/135843"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "failure_to_load_datasource|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.failure_to_load_datasource.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2813",
+              "https://projects.engineering.redhat.com/browse/CEECBA-3510"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1738607"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_i40e_data_corruption_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_i40e_data_corruption_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2678"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3572961"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1404060",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1413101"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_iwlwifi_driver_sysctl_conf_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_iwlwifi_driver_sysctl_conf_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3618"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4205041"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1718118"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "mail_files_left|NONE_KEY",
+          "component": "telemetry.rules.plugins.service.mail_files_left.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/258603"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "unsupported_journal_mode|NONE_KEY",
+          "component": "telemetry.rules.plugins.filesystem.unsupported_journal_mode.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4938"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/358963",
+              "https://access.redhat.com/solutions/424073"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_target_available_memory_size|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_target_available_memory_size.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4303",
+              "https://issues.redhat.com/browse/CEECBA-4967",
+              "https://issues.redhat.com/browse/CEECBA-5255"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1868698"
+            ],
+            "kcs": [
+              "https://access.redhat.com/articles/5676371"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "pkla_check_authorization_process_task_uninterruptible_or_defunct|NONE_KEY",
+          "component": "telemetry.rules.plugins.shells.pkla_check_authorization_process_task_uninterruptible_or_defunct.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3213721"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1570907"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2539",
+              "https://issues.redhat.com/browse/CEECBA-4382"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ixgbevf_networking_enhance|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.ixgbevf_networking_enhance.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2740491"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-4120"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1274175"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_i40e_mdd_detection_pf_reset|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_i40e_mdd_detection_pf_reset.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/4385541"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-4093"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "support_for_next_gen_arm_instances|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.support_for_next_gen_arm_instances.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3765"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1770979"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_mlx5_infiniband_drv_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_mlx5_infiniband_drv_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4700",
+              "https://issues.redhat.com/browse/CEECBA-5130"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5601811"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1880184",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1789380"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_tcp_pkt_drp_alloc_fail|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_tcp_pkt_drp_alloc_fail.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3171",
+              "https://projects.engineering.redhat.com/browse/CEECBA-3241"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4091971"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1696664",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1704326"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_bnx2x_link_down_driver_fw_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_bnx2x_link_down_driver_fw_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/68961",
+              "https://access.redhat.com/solutions/388813"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_qlcnic_interface_hang_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_qlcnic_interface_hang_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2354511"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3337"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1403143",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1342659"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "performance_impact_due_to_disabled_pcid_feature|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.performance_impact_due_to_disabled_pcid_feature.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3987"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1691421",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1697940"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "slowness_console_aspeed_grahics_driver|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.slowness_console_aspeed_grahics_driver.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3664"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4545311"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1780145",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1780146",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1780147",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1739623"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hyperv_guest_set_mtu_failure|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.hyperv_guest_set_mtu_failure.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2705511"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "unable_to_reset_password_on_rhel8_azure|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.unable_to_reset_password_on_rhel8_azure.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [
+            "azure",
+            "rhel8"
+          ],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2804"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1708040"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_ovs_vxlan_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_ovs_vxlan_panic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2938"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4280441"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_infiniband_ipoib_crash_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_infiniband_ipoib_crash_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3465401"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vmxnet3_interface_hang|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vmxnet3_interface_hang.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2837431"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "oracle_cluster_avahi_daemon|NONE_KEY",
+          "component": "telemetry.rules.plugins.oracle.oracle_cluster_avahi_daemon.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/25463"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-144",
+              "https://issues.redhat.com/browse/CEECBA-4633"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "nmi_dazed_and_confused|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.nmi_dazed_and_confused.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/35402",
+              "https://access.redhat.com/solutions/26467"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_on_azure|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.kdump_on_azure.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2179"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3091051"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ethernet_amd_epyc_iommu_performance_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.ethernet_amd_epyc_iommu_performance_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2521"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3237861"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1508644",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1531456"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_intel_nic_hang|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_intel_nic_hang.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/119653"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4317"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "networking_lvs_slow_performance|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.networking_lvs_slow_performance.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/node/92973"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "oracle_db_ps_fail_no_buff_mem|NONE_KEY",
+          "component": "telemetry.rules.plugins.oracle.oracle_db_ps_fail_no_buff_mem.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2945981"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3989"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hypervisor_bridge_bonding_mode|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.bonding.hypervisor_bridge_bonding_mode.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-1045"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/67546"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "osp_certificates_expiration|NONE_KEY",
+          "component": "telemetry.rules.plugins.osp.osp_certificates_expiration.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2942211"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "neutron_osp11_ha_bug|NONE_KEY",
+          "component": "telemetry.rules.plugins.osp.neutron_osp11_ha_bug.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1461110",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1461111",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1461113"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "only_one_cpu_after_l1ft_udpate|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.only_one_cpu_after_l1ft_udpate.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3596941"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2525"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1623255"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "be2net_dropped_large_packets|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.be2net_dropped_large_packets.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/659453"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-524"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_udev_sfc_interface_name_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_udev_sfc_interface_name_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3134621"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "docker_daemon_huge_memory_usage|NONE_KEY",
+          "component": "telemetry.rules.plugins.container.docker_daemon_huge_memory_usage.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3223811"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "aws_microcode_loaded|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.aws_microcode_loaded.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3170"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1716333"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_sfc_nic_tx_timeout|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_sfc_nic_tx_timeout.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2190681"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-4199"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "corosync_heartbeat_bonding|NONE_KEY",
+          "component": "telemetry.rules.plugins.clusterha.corosync_heartbeat_bonding.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3068841",
+              "https://access.redhat.com/solutions/27604"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3346"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_with_cbsensor_module|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_with_cbsensor_module.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2929"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4544501"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "setup_netdev_packetdrop_params|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.setup_netdev_packetdrop_params.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1241943"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ocp_elasticsearch_pod_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.shift.ocp_elasticsearch_pod_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/4395531"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3459",
+              "https://issues.redhat.com/browse/CEECBA-5276"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "fips_enabled_rngd_cpu_consumption|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.fips_enabled_rngd_cpu_consumption.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4702"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5547981"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1884857"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_rcu_threads_online_cpus|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_rcu_threads_online_cpus.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1404313"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1208895"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3169"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_ifcfg_backup_conf_files|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_ifcfg_backup_conf_files.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3950",
+              "https://projects.engineering.redhat.com/browse/CEECBA-4114"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/68127"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ceph_increase_min_free_kbytes|NONE_KEY",
+          "component": "telemetry.rules.plugins.ceph.ceph_increase_min_free_kbytes.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2244"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3031521"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1704326"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_manager_vlan_uuid_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_manager_vlan_uuid_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3421371"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1553595"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_mlx5_core_melanox_firmware_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_mlx5_core_melanox_firmware_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2975"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3122991"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1463367",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1497604"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "xen_netfront_packet_loss|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.xen_netfront_packet_loss.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2387391"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3480"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1348581"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_randome_usercopy|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_randome_usercopy.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/4547651"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4254"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "neighbour_table_overflow|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.neighbour_table_overflow.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/23454",
+              "https://access.redhat.com/solutions/3588721"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "ocp_certificates_expiration|NONE_KEY",
+          "component": "telemetry.rules.plugins.shift.ocp_certificates_expiration.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3850",
+              "https://issues.redhat.com/browse/CEECBA-5276"
+            ],
+            "product_documentation": [
+              "https://docs.openshift.com/container-platform/3.11/install_config/redeploying_certificates.html"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_blue_flame|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_blue_flame.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/437113"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_cgroup_slabmem_leak_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_cgroup_slabmem_leak_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3291481"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4606"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1507149",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1752421"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_bna_driver_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_bna_driver_panic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2820921"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "rpm_database_problems|NONE_KEY",
+          "component": "telemetry.rules.plugins.other.rpm_database_problems.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/1330653"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_vmware_guest_vmci_sock_transport|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_vmware_guest_vmci_sock_transport.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-4757"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/1582653"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/1253971"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "mssql_sulogin_root_shell|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.mssql_sulogin_root_shell.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2421"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "aws_cloud_init_incorrectly_handles_multiple_authkeys|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.aws_cloud_init_incorrectly_handles_multiple_authkeys.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3397",
+              "https://issues.redhat.com/browse/CEECBA-4424"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1642008"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "intel_sb_edac_driver_kernel_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.intel_sb_edac_driver_kernel_panic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3209"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2722761"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1353808"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_selinux_virtualization|NONE_KEY",
+          "component": "prodsec.rules.hardening_selinux_virtualization.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/6144012"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "aws_vif_driver_mtu_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.aws_vif_driver_mtu_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3578"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1502554"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_selinux_container|NONE_KEY",
+          "component": "prodsec.rules.hardening_selinux_container.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/6144032"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "aws_cloud_init_overrides_local_network_config|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.aws_cloud_init_overrides_local_network_config.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3442"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4350351"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1653131",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1691685"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cloud_init_fails_to_configure_network_device|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.cloud_init_fails_to_configure_network_device.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2927"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1602784"
+            ],
+            "changelog": [
+              "https://code.launchpad.net/~otubo/cloud-init/+git/cloud-init/+merge/353436"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "aws_cloud_init_support_for_imdsv2|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.aws_cloud_init_support_for_imdsv2.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3599",
+              "https://projects.engineering.redhat.com/browse/CEECBA-4195",
+              "https://issues.redhat.com/browse/CEECBA-4343"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4977371"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1803095",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1803094",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1827207",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1866612",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1869670"
+            ],
+            "product_documentation": [
+              "https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_hv_netvsc_driver_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_driver_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2531"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3949321"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1661632",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1679997"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vlan_corrupt_traffic|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vlan_corrupt_traffic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2966631"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_hv_netvsc_driver_ring_buffer_signal_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_driver_ring_buffer_signal_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2689"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3489351"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1591976",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1605089"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "oracle_tuning|NONE_KEY",
+          "component": "telemetry.rules.plugins.oracle.oracle_tuning.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/39188"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-233",
+              "https://projects.engineering.redhat.com/browse/CEECBA-3830"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vmxnet3_discard_ipv6|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vmxnet3_discard_ipv6.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2987791"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "high_latency_issue_with_hv_netvsc_driver|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.high_latency_issue_with_hv_netvsc_driver.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3604",
+              "https://projects.engineering.redhat.com/browse/CEECBA-4010"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1805950",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1848130"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "CVE_2021_38647_omi|NONE_KEY",
+          "component": "prodsec.rules.CVE_2021_38647_omi.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vxlan_panic_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vxlan_panic_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2777"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3734801"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vmxnet3_driver_panic|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vmxnet3_driver_panic.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2662661"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "systemd_non_persistent_ifname|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.systemd_non_persistent_ifname.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4357"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2435891",
+              "https://access.redhat.com/solutions/283233"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1520983",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1793974",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1859926"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_third_party_drivers|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_third_party_drivers.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4304"
+            ],
+            "product_documentation": [
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements",
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/installing-and-configuring-kdump_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1879558"
+            ],
+            "kcs": [
+              "https://access.redhat.com/articles/5679941"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "tg3_driver_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.tg3_driver_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-1834"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/69382"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_packet_drop_cisco_vic_enic_driver|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_packet_drop_cisco_vic_enic_driver.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/387813"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4542"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_hv_netvsc_drv_miss_tx_queue_wakeup|NONE_KEY",
+          "component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_drv_miss_tx_queue_wakeup.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2879",
+              "https://issues.redhat.com/browse/CEECBA-4401"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1841900",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1781322",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1774687",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1842485"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5189981"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "be2net_mccq|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.be2net_mccq.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/node/35572",
+              "https://access.redhat.com/solutions/60857"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_bnx2x_ptp_kernel_panic_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_bnx2x_ptp_kernel_panic_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3007"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3192002"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1344743",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1518669"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "cannot_update_rhv_manager_due_to_ansible_version_conflict|NONE_KEY",
+          "component": "telemetry.rules.plugins.rhev.cannot_update_rhv_manager_due_to_ansible_version_conflict.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4639"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5480561"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1887268",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1887142"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "qlcnic_driver_crash|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.qlcnic_driver_crash.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/916883"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_rt_kernel_panic_interrupt_context_preemption|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_rt_kernel_panic_interrupt_context_preemption.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2552"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3061081"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1402121",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1402837",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1401779"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "crashkernel_reservation_value|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.crashkernel_reservation_value.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3483431",
+              "https://access.redhat.com/solutions/916043",
+              "https://access.redhat.com/solutions/3698411",
+              "https://access.redhat.com/solutions/1186753"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3863",
+              "https://issues.redhat.com/browse/CEECBA-4381",
+              "https://issues.redhat.com/browse/CEECBA-5671"
+            ],
+            "product_documentation": [
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements",
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/supported-kdump-configurations-and-targets_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "panic_be2net_driver|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.panic_be2net_driver.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/node/60123"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_matrox_vga_legacy_bios_mgag200_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_matrox_vga_legacy_bios_mgag200_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-4903"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5770681",
+              "https://access.redhat.com/solutions/4639181"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1913519"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_veth_corrupt_pkt_application|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_veth_corrupt_pkt_application.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2140"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2173981"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "insights_client_core_collection|NONE_KEY",
+          "component": "telemetry.rules.plugins.other.insights_client_core_collection.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5042"
+            ],
+            "kcs": [
+              "https://access.redhat.com/articles/5699071"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vlan_offloading_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vlan_offloading_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3658131"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1640645"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_ixgbe_nic_reset|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_ixgbe_nic_reset.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2070703"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-4062"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_ixgbe_nic_intel_X550_performance_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_ixgbe_nic_intel_X550_performance_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3243"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4636801"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1781429"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "missing_boot_files|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.missing_boot_files.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/369233"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "oracle_storage_tuning|NONE_KEY",
+          "component": "telemetry.rules.plugins.oracle.oracle_storage_tuning.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/2607861"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3829"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_cisco_VIC_irq_imbalance|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_cisco_VIC_irq_imbalance.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2167"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4126461"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "selinux_selinuxtype|NONE_KEY",
+          "component": "telemetry.rules.plugins.other.selinux_selinuxtype.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/232483",
+              "https://access.redhat.com/solutions/6062341"
+            ],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5466",
+              "https://projects.engineering.redhat.com/browse/CEECBA-641"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_ibmvnic_driver_kernel_panic_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_ibmvnic_driver_kernel_panic_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3769"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/5059441"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1783775",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1828708"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_nvidia_nouveau_driver_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_nvidia_nouveau_driver_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3378"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2990791"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1449338"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "check_debugshell|NONE_KEY",
+          "component": "telemetry.rules.plugins.service.check_debugshell.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2397"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "xen_pv_guest_boot_failure|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.xen_pv_guest_boot_failure.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3307791"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1531294"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3478",
+              "https://projects.engineering.redhat.com/browse/CEECBA-4305"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_xen_pv_guest_fails|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_xen_pv_guest_fails.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3115"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3544391"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1487754"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_vlan_i40e_driver_offloading_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_vlan_i40e_driver_offloading_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2797"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3662011"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1589450"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_lpfc_be2net_nic_failure|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_lpfc_be2net_nic_failure.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2224"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3964901"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1657981",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1683908"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_crash_at_shpc_probe|NONE_KEY",
+          "component": "telemetry.rules.plugins.vmware.kernel_crash_at_shpc_probe.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2672",
+              "https://issues.redhat.com/browse/CEECBA-5193"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3688401"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kdump_iommu|NONE_KEY",
+          "component": "telemetry.rules.plugins.kdump.kdump_iommu.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/69019"
+            ],
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-457"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "kernel_panic_uefi_boot_loader_nopti_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.kernel_panic_uefi_boot_loader_nopti_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3314"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4214721"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1540061",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1565700"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_intel_uhd_graphic_network_card_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_intel_uhd_graphic_network_card_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3013"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4154511"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1711234"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "xen_pv_guest_panic_with_eagerfpu|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.xen_pv_guest_panic_with_eagerfpu.retport",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3551871"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_qlogic_qede_nic_init_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_qlogic_qede_nic_init_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3720331"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "el7_to_el8_upgrade|NONE_KEY",
+          "component": "telemetry.rules.plugins.leapp.el7_to_el8_upgrade.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-3199",
+              "https://issues.redhat.com/browse/CEECBA-4533",
+              "https://issues.redhat.com/browse/CEECBA-3792",
+              "https://issues.redhat.com/browse/CEECBA-4677",
+              "https://issues.redhat.com/browse/CEECBA-5079",
+              "https://issues.redhat.com/browse/CEECBA-5294"
+            ],
+            "product_documentation": [
+              "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/4120411",
+              "https://access.redhat.com/solutions/4824451",
+              "https://access.redhat.com/solutions/5154031"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_nic_i40e_i40evf_driver_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.network_nic_i40e_i40evf_driver_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2937"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/3753111"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1722774",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1454890"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hpdsa_version_incompatible|NONE_KEY",
+          "component": "telemetry.rules.plugins.kernel.hpdsa_version_incompatible.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3337891"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "oracle_java_se_access_not_available|NONE_KEY",
+          "component": "telemetry.rules.plugins.java.oracle_java_se_access_not_available.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3253281",
+              "https://access.redhat.com/solutions/732883"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "network_team_bond_slave_be2net_driver_issue|NONE_KEY",
+          "component": "telemetry.rules.plugins.networking.bonding.network_team_bond_slave_be2net_driver_issue.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-2611"
+            ],
+            "kcs": [
+              "https://access.redhat.com/solutions/2328621"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1337318",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1382354"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "fc_hba_init_failure_during_boot|NONE_KEY",
+          "component": "telemetry.rules.plugins.storage.fc_hba_init_failure_during_boot.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3421081"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1570785",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1584377",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1657981"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "aws_kdump_boot_stuck_specific_instance_type|NONE_KEY",
+          "component": "telemetry.rules.plugins.aws.aws_kdump_boot_stuck_specific_instance_type.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "jira": [
+              "https://projects.engineering.redhat.com/browse/CEECBA-4054"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1844522"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_httpd_virtualhost|NONE_KEY",
+          "component": "prodsec.rules.hardening_httpd_virtualhost.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3022811"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "none_id": "hardening_ssh_hmac_cipher|NONE_KEY",
+          "component": "prodsec.rules.hardening_ssh_hmac_cipher.report",
+          "type": "none",
+          "key": "NONE_KEY",
+          "details": {
+            "type": "none",
+            "none_key": "NONE_KEY"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/420283https://access.redhat.com/articles/3666211"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        }
+      ],
+      "pass": [
+        {
+          "pass_id": "CVE_2017_7184_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_7184_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-7184": "The system is not running a vulnerable kernel."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1435153"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_5195_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_5195_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-5195": "The running kernel version is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/2706661"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1384344"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_5696_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_5696_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-5696": "The running kernel version is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/challengeack"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1354708"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_2636_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_2636_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-2636": "Vulnerable kernel not running"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/CVE-2017-2636"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1428319"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_0728_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_0728_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-0728": "The current running kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/2132951"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1297475"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_tls_key_perms|OK",
+          "component": "prodsec.rules.hardening_tls_key_perms.report",
+          "type": "pass",
+          "key": "OK",
+          "details": {
+            "type": "pass",
+            "pass_key": "OK"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_1000253_loadelf|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_1000253_loadelf.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-1000253": "Vulnerable kernel not running"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/3189592"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1492212"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_1000405_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_1000405_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-1000405": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/3253921"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1516514"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_0155_gpu_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_0155_gpu_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-0154": "Vulnerable module not loaded.",
+              "CVE-2019-0155": "Vulnerable module not loaded."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/i915-graphics"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1724393",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1724398"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_6074_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_6074_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-6074": "Vulnerable kernel version is not running"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/2934281"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1423071"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_14615_gpu_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_14615_gpu_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-14615": "Vulnerable module not loaded."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1789209"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_12653_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_12653_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-12653": "Vulnerable kernel module not installed.",
+              "CVE-2020-12654": "Vulnerable kernel module not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1831868",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1832530"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_12657_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_12657_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-12657": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/CVE-2020-12657"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_passwd_perms|OK",
+          "component": "prodsec.rules.hardening_passwd_perms.report",
+          "type": "pass",
+          "key": "OK",
+          "details": {
+            "type": "pass",
+            "pass_key": "OK"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_11048_php|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_11048_php.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-11048": "HTTPD or NGINX web server is not installed or active"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_smbloris_samba|Vulnerable package not installed",
+          "component": "prodsec.rules.CVE_2017_smbloris_samba.report",
+          "type": "pass",
+          "key": "Vulnerable package not installed",
+          "details": {
+            "type": "pass",
+            "pass_key": "Vulnerable package not installed"
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/smbloris"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1478016"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_11135_cpu_taa|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_11135_cpu_taa.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-11135": "System is not vulnerable or is mitigated."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/tsx-asynchronousabort"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1753062"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2015_5600|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2015_5600.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2015-5600": "sshd settings not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1245969"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_cryptopol_ssh_client|openssh-clients governed by crypto policies.",
+          "component": "prodsec.rules.hardening_cryptopol_ssh_client.report",
+          "type": "pass",
+          "key": "openssh-clients governed by crypto policies.",
+          "details": {
+            "type": "pass",
+            "pass_key": "openssh-clients governed by crypto policies."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3666211"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2015_7181_2_3_nss_nspr|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2015_7181_2_3_nss_nspr.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2015-7181": "Vulnerable package is not installed.",
+              "CVE-2015-7182": "Vulnerable package is not installed.",
+              "CVE-2015-7183": "Vulnerable package is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/2043623"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1269345",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1269351",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1269353"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_1002105_kubernetes|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_1002105_kubernetes.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-1002105": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/3716411"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1648138"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_cryptopol_sshd|sshd governed by crypto policies.",
+          "component": "prodsec.rules.hardening_cryptopol_sshd.report",
+          "type": "pass",
+          "key": "sshd governed by crypto policies.",
+          "details": {
+            "type": "pass",
+            "pass_key": "sshd governed by crypto policies."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3666211"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2015_7501_commons_collections|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2015_7501_commons_collections.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2015-7501": "Vulnerable package is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2045023"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1279330"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2021_3156_sudo|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2021_3156_sudo.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2021-3156": "The sudo package is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/RHSB-2021-002"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1917684"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "rpm_packages_checksum|rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches.",
+          "component": "prodsec.rules.rpm_packages_checksum.report",
+          "type": "pass",
+          "key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches.",
+          "details": {
+            "type": "pass",
+            "pass_key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches."
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_14835_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_14835_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-14835": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/kernel-vhost"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1750727"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_1000251_kernel_blueborne|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_1000251_kernel_blueborne.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-1000251": "Vulnerable kernel not running"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/blueborne"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1489716"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_cryptopol_krb5|krb5 governed by crypto policies.",
+          "component": "prodsec.rules.hardening_cryptopol_krb5.report",
+          "type": "pass",
+          "key": "krb5 governed by crypto policies.",
+          "details": {
+            "type": "pass",
+            "pass_key": "krb5 governed by crypto policies."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3666211"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVEs_samba_badlock|All CVEs passed.",
+          "component": "prodsec.rules.CVEs_samba_badlock.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-2118": "The vulnerable samba version is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/badlock",
+              "https://access.redhat.com/articles/2243351"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1317990"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "bash_injection|All CVEs passed.",
+          "component": "prodsec.rules.bash_injection.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2014-6271": "Vulnerable package not installed",
+              "CVE-2014-7169": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/1200223",
+              "https://access.redhat.com/articles/1213683"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1141597",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1146319"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_cryptopol_libssh|libssh governed by crypto policies.",
+          "component": "prodsec.rules.hardening_cryptopol_libssh.report",
+          "type": "pass",
+          "key": "libssh governed by crypto policies.",
+          "details": {
+            "type": "pass",
+            "pass_key": "libssh governed by crypto policies."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3666211"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_1000366_glibc|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_1000366_glibc.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-1000364": "Vulnerable kernel and glibc not running",
+              "CVE-2017-1000366": "Vulnerable kernel and glibc not running"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/stackguard"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1461333"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_1000368_sudo|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_1000368_sudo.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-1000368": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/3059071"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1459152"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_13077_wpa_supplicant|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_13077_wpa_supplicant.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-13077": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/kracks"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1491692"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_5461_nss|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_5461_nss.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-5461": "Vulnerable package(s) not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1440080"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_7494_samba|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_7494_samba.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-7494": "The system is not vulnerable, SELinux mitigates the issue"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/3034621"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1450347"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_11477_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_11477_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-11477": "Kernel is not vulnerable.",
+              "CVE-2019-11478": "Kernel is not vulnerable.",
+              "CVE-2019-11479": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              ""
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/1719123"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_25681_7_dnsmasq|Vulnerable package not installed.",
+          "component": "prodsec.rules.CVE_2020_25681_7_dnsmasq.report",
+          "type": "pass",
+          "key": "Vulnerable package not installed.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Vulnerable package not installed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/RHSB-2021-001"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1881875",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1882014",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1882018",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1889686",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1889688",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1890125",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1891568"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_13272_kernel_ptrace|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_13272_kernel_ptrace.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-13272": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/4292201"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1730895"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2015_3456|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2015_3456.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2015-3456": "Vulnerable package not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/1444903"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1218611"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_25661_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_25661_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-25661": "Kernel is not vulnerable.",
+              "CVE-2020-25662": "Kernel is not vulnerable.",
+              "CVE-2020-24490": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/BleedingTooth"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1891483",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1891484",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1888449"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_2315_24_git|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_2315_24_git.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-2315": "Vulnerable package not installed",
+              "CVE-2016-2324": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/2201201"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1317981"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_2776_bind|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_2776_bind.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-2776": "Vulnerable package is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1378380"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_19788_polkit|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_19788_polkit.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-19788": "Vulnerable package is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/25404"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1655925"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_1112_glusterfs|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_1112_glusterfs.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-1112": "Vulnerable glusterfs-server-3.8.4-54.7 is not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/3422521"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1570891"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_3714_imagemagick|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_3714_imagemagick.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-3714": "Vulnerable package is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/ImageTragick"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1332492"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_12351_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_12351_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-12351": "Kernel is not vulnerable.",
+              "CVE-2020-12352": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/5493631"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1886521"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_1000250_bluez|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_1000250_bluez.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-1000250": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1489446"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2015_7547_glibc|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2015_7547_glibc.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2015-7547": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/2168451"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1293532"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_12207_cpu_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_12207_cpu_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-12207": "Cannot detect this vulnerability in VM guest."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/ifu-page-mce"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1646768"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_8779_rpc|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_8779_rpc.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-8779": "The system is not vulnerable, mitigation is applied"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3025811",
+              "https://access.redhat.com/solutions/3053461"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1448124"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_1125_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_1125_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-1125": "Vulnerability file indicates system not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/4329821"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1724389"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVEs_Top10_2015_flash_plugin|All CVEs passed.",
+          "component": "prodsec.rules.CVEs_Top10_2015_flash_plugin.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2015-0359": "Firefox is not installed.",
+              "CVE-2015-5119": "Firefox is not installed.",
+              "CVE-2015-3113": "Firefox is not installed.",
+              "CVE-2015-5122": "Firefox is not installed.",
+              "CVE-2015-0311": "Firefox is not installed.",
+              "CVE-2015-3090": "Firefox is not installed.",
+              "CVE-2015-0336": "Firefox is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1188329",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1211869",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1240832",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1235036",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1242216",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1185296",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1221037",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1201636"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVEs_Top10_2016_flash_plugin|All CVEs passed.",
+          "component": "prodsec.rules.CVEs_Top10_2016_flash_plugin.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-1019": "Firefox is not installed.",
+              "CVE-2016-4117": "Firefox is not installed.",
+              "CVE-2015-8651": "Firefox is not installed.",
+              "CVE-2016-1010": "Firefox is not installed.",
+              "CVE-2015-8446": "Firefox is not installed.",
+              "CVE-2015-7645": "Firefox is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1324353",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1335058",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1397987",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1316809",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1289771",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1271966"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_10713_grub|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_10713_grub.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-10713": "Vulnerable package versions not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/grub2bootloader"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1825243"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_14491_dnsmasq|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_14491_dnsmasq.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-14491": "Vulnerable package not installed"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/3199382"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1495409"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_8897_kernel_popss|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_8897_kernel_popss.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-8897": "Vulnerable kernel version is not running",
+              "CVE-2018-1087": "Vulnerable kernel version is not running"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/pop_ss"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1567074"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_5715_cpu_virt|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_5715_cpu_virt.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-5715": "The system is not exploitable because the relevant installed packages are not vulnerable and because the current combination and configuration of the CPU and kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/speculativeexecution"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1519780"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2017_5753_4_cpu_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2017_5753_4_cpu_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2017-5753": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+              "CVE-2017-5715": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+              "CVE-2017-5754": "The current combination and configuration of the CPU and kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/speculativeexecution"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1519778",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1519781"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2021_30465_runc|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2021_30465_runc.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2021-30465": "Vulnerable package not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/RHSB-2021-004"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/CVE-2021-30465"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_3620_cpu_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_3620_cpu_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-3620": "Vulnerability file indicates system not vulnerable.",
+              "CVE-2018-3646": "Vulnerability file indicates system not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/L1TF"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1585005"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_12321_linux_firmware|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_12321_linux_firmware.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-12321": "linux-firmware is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/CVE-2020-12321"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_14634_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_14634_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-14634": "System with less than 16GB RAM cannot be exploited"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/mutagen-astronomy"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1624498"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_1111_dhcp|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_1111_dhcp.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-1111": "Vulnerable config not detected"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/3442151"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1567974"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_14372_grub|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_14372_grub.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-14372": "The vulnerability is not applicable - system doesn't have Secure Boot enabled."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/RHSB-2021-003"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1873150"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "heartbleed|All CVEs passed.",
+          "component": "prodsec.rules.heartbleed.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2014-0160": "The vulnerable openssl version is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/781793"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1084875"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_tls_satellite|Httpd service is not installed.",
+          "component": "prodsec.rules.hardening_tls_satellite.report",
+          "type": "pass",
+          "key": "Httpd service is not installed.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Httpd service is not installed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2157131",
+              "https://access.redhat.com/articles/1232123",
+              "https://access.redhat.com/solutions/26833"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_unencrypted_rsh|Rsh not in use or not listening on public socket",
+          "component": "prodsec.rules.hardening_unencrypted_rsh.report",
+          "type": "pass",
+          "key": "Rsh not in use or not listening on public socket",
+          "details": {
+            "type": "pass",
+            "pass_key": "Rsh not in use or not listening on public socket"
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_0800_openssl_drown|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_0800_openssl_drown.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-0800": "Vulnerable package is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/articles/2176731"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1310593"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_tls_vsftpd|Vsftpd service is not installed.",
+          "component": "prodsec.rules.hardening_tls_vsftpd.report",
+          "type": "pass",
+          "key": "Vsftpd service is not installed.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Vsftpd service is not installed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2157131",
+              "https://access.redhat.com/articles/1232123",
+              "https://access.redhat.com/solutions/3436",
+              "https://access.redhat.com/solutions/1320473"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_unsupported_xus|The system doesn't run EUS/AUS/TUS/E4S/ELS.",
+          "component": "prodsec.rules.hardening_unsupported_xus.report",
+          "type": "pass",
+          "key": "The system doesn't run EUS/AUS/TUS/E4S/ELS.",
+          "details": {
+            "type": "pass",
+            "pass_key": "The system doesn't run EUS/AUS/TUS/E4S/ELS."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/node/721513",
+              "https://access.redhat.com/articles/4520991"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_unencrypted_telnet|Telnet not in use or not listening on public socket.",
+          "component": "prodsec.rules.hardening_unencrypted_telnet.report",
+          "type": "pass",
+          "key": "Telnet not in use or not listening on public socket.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Telnet not in use or not listening on public socket."
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_unencrypted_avahi|Avahi not in use.",
+          "component": "prodsec.rules.hardening_unencrypted_avahi.report",
+          "type": "pass",
+          "key": "Avahi not in use.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Avahi not in use."
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_ipv6_ip6tables|iptables is not installed.",
+          "component": "prodsec.rules.hardening_ipv6_ip6tables.report",
+          "type": "pass",
+          "key": "iptables is not installed.",
+          "details": {
+            "type": "pass",
+            "pass_key": "iptables is not installed."
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_unsupported_zstream|The system runs supported non-EUS Z-Stream or can get latest updates via yum.",
+          "component": "prodsec.rules.hardening_unsupported_zstream.report",
+          "type": "pass",
+          "key": "The system runs supported non-EUS Z-Stream or can get latest updates via yum.",
+          "details": {
+            "type": "pass",
+            "pass_key": "The system runs supported non-EUS Z-Stream or can get latest updates via yum."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/238533",
+              "https://access.redhat.com/solutions/2761031",
+              "https://access.redhat.com/solutions/3433671"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_tls_nginx|Nginx service is not installed.",
+          "component": "prodsec.rules.hardening_tls_nginx.report",
+          "type": "pass",
+          "key": "Nginx service is not installed.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Nginx service is not installed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2157131",
+              "https://access.redhat.com/articles/1232123"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_tls_httpd|Httpd service is not installed.",
+          "component": "prodsec.rules.hardening_tls_httpd.report",
+          "type": "pass",
+          "key": "Httpd service is not installed.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Httpd service is not installed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/2157131",
+              "https://access.redhat.com/articles/1232123",
+              "https://access.redhat.com/solutions/26833"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_tls_dovecot|Dovecot service is not installed.",
+          "component": "prodsec.rules.hardening_tls_dovecot.report",
+          "type": "pass",
+          "key": "Dovecot service is not installed.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Dovecot service is not installed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/120383",
+              "https://access.redhat.com/solutions/2157131",
+              "https://access.redhat.com/articles/1232123"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2018_1000115_memcached|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2018_1000115_memcached.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2018-1000115": "memcached not accessible from external UDP connections"
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/solutions/3369081"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1551182"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_9490_httpd|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_9490_httpd.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-9490": "Vulnerable httpd version is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/CVE-2020-9490"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2021_27365_kernel|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2021_27365_kernel.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2021-27365": "Kernel is not vulnerable."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "bugzilla": [
+              "https://bugzilla.redhat.com/CVE-2021-27365"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_unencrypted_ntalk|Ntalk not in use or not available to public addresses.",
+          "component": "prodsec.rules.hardening_unencrypted_ntalk.report",
+          "type": "pass",
+          "key": "Ntalk not in use or not available to public addresses.",
+          "details": {
+            "type": "pass",
+            "pass_key": "Ntalk not in use or not available to public addresses."
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "hardening_unencrypted_nis|NIS is not running or not available to public access.",
+          "component": "prodsec.rules.hardening_unencrypted_nis.report",
+          "type": "pass",
+          "key": "NIS is not running or not available to public access.",
+          "details": {
+            "type": "pass",
+            "pass_key": "NIS is not running or not available to public access."
+          },
+          "tags": [],
+          "links": {},
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2019_5736_runc|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2019_5736_runc.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2019-5736": "Vulnerable package not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/runcescape"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1664908"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2016_9962_docker|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2016_9962_docker.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2016-9962": "Vulnerable package is not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/cve-2016-9962"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1409531"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_11100_haproxy|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_11100_haproxy.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-11100": "Vulnerable package not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/haproxy"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1819111"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        },
+        {
+          "pass_id": "CVE_2020_14298_docker|All CVEs passed.",
+          "component": "prodsec.rules.CVE_2020_14298_docker.report",
+          "type": "pass",
+          "key": "All CVEs passed.",
+          "details": {
+            "cves": {
+              "CVE-2020-14298": "Vulnerable package not installed.",
+              "CVE-2020-14300": "Vulnerable package not installed.",
+              "CVE-2016-8867": "Vulnerable package not installed."
+            },
+            "type": "pass",
+            "pass_key": "All CVEs passed."
+          },
+          "tags": [],
+          "links": {
+            "kcs": [
+              "https://access.redhat.com/security/vulnerabilities/runc-regression-docker-1.13.1-108"
+            ],
+            "bugzilla": [
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1848239",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1848829",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=1390163"
+            ]
+          },
+          "system_id": "a319580a-2321-47c7-b061-886548bea067"
+        }
+      ],
+      "analysis_metadata": {
+        "start": "2021-12-30T12:54:39.025114+00:00",
+        "finish": "2021-12-30T12:54:40.696393+00:00",
+        "execution_context": "insights.core.context.SerializedArchiveContext",
+        "plugin_sets": {
+          "insights-core": {
+            "version": "insights-core-3.0.254-1",
+            "commit": "placeholder"
+          },
+          "insights-plugins": {
+            "version": "insights-plugins-2.0.200-1",
+            "commit": "placeholder"
+          },
+          "insights-prodsec-rules": {
+            "version": "insights-prodsec-rules-1.0.133-1",
+            "commit": "placeholder"
+          }
+        }
+      }
+    }
+  }

--- a/sample-files/insights-engine-result-no-pcp.json
+++ b/sample-files/insights-engine-result-no-pcp.json
@@ -1,0 +1,6781 @@
+{
+	"input": {
+		"platform_metadata": {
+			"account": "0000001",
+			"b64_identity": "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMSIsInR5cGUiOiAiVXNlciIsInVzZXIiOiB7InVzZXJuYW1lIjogInR1c2VyQHJlZGhhdC5jb20iLCJlbWFpbCI6ICJ0dXNlckByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6ICJ0ZXN0IiwibGFzdF9uYW1lIjogInVzZXIiLCJpc19hY3RpdmUiOiB0cnVlLCJpc19vcmdfYWRtaW4iOiBmYWxzZSwgImlzX2ludGVybmFsIjogdHJ1ZSwgImxvY2FsZSI6ICJlbl9VUyJ9LCJpbnRlcm5hbCI6IHsgIm9yZ19pZCI6ICIwMDAwMDEifX19Cg==",
+			"category": "collection",
+			"elapsed_time": 1640765585.775109,
+			"extras": {},
+			"host": {},
+			"id": null,
+			"metadata": {
+				"reporter": "",
+				"stale_timestamp": "0001-01-01T00:00:00Z"
+			},
+			"payload_id": null,
+			"principal": "000001",
+			"request_id": "f77010e80955/miYkbDetAo-000007",
+			"satellite_managed": null,
+			"service": "advisor",
+			"size": 214015,
+			"timestamp": "2021-12-29T08:13:04.771122876Z",
+			"url": "http://minio:9000/insights-upload-perma/f77010e80955/miYkbDetAo-000007?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211229%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211229T081304Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=1cfb9076ed2597424033e9ad1dad73b5d75397c672ab9fd98f14316a250f84a6",
+			"validation": null,
+			"test": null,
+			"is_ros": "true"
+		},
+		"metadata": {
+			"request_id": "f77010e80955/miYkbDetAo-000007"
+		},
+		"host": {
+			"bios_uuid": "ec2abcd8-7cda-e6ba-3e6a-42cf9907a7ce",
+			"satellite_id": null,
+			"subscription_manager_id": "9555a556-5737-45ec-91e4-37203ae66c6e",
+			"stale_warning_timestamp": "2022-01-06T13:13:06.760054+00:00",
+			"per_reporter_staleness": {
+				"puptoo": {
+					"last_check_in": "2021-12-29T08:13:06.863705+00:00",
+					"stale_timestamp": "2021-12-30T13:13:06.760054+00:00",
+					"check_in_succeeded": true
+				}
+			},
+			"fqdn": "ip-172-31-25-176.ec2.internal",
+			"system_profile": {
+				"os_release": "8.4",
+				"os_kernel_version": "4.18.0",
+				"satellite_managed": false
+			},
+			"ip_addresses": ["172.31.25.176"],
+			"created": "2021-12-17T19:01:58.006837+00:00",
+			"updated": "2021-12-29T08:13:06.863986+00:00",
+			"reporter": "puptoo",
+			"culled_timestamp": "2022-01-13T13:13:06.760054+00:00",
+			"id": "22992ae9-8b16-4b7a-9fd0-22f2af31d246",
+			"rhel_machine_id": null,
+			"display_name": "ip-172-31-25-176.ec2.internal",
+			"stale_timestamp": "2021-12-30T13:13:06.760054+00:00",
+			"insights_id": "0b6cf763-ea84-4961-a015-5b948b1366ee",
+			"account": "0000001",
+			"provider_type": null,
+			"tags": [],
+			"provider_id": null,
+			"ansible_host": null,
+			"mac_addresses": ["0a:76:4b:32:60:bd", "00:00:00:00:00:00"]
+		},
+		"type": "updated",
+		"timestamp": "2021-12-29T08:13:06.899242+00:00"
+	},
+	"results": {
+		"system": {
+			"metadata": {
+				"timezone_information": {
+					"utcoffset": 0,
+					"timezone": "UTC"
+				},
+				"bios_information": {
+					"bios_revision": "4.2",
+					"release_date": "08/24/2006",
+					"vendor": "Xen",
+					"version": "4.2.amazon"
+				},
+				"system_information": {
+					"product_name": "HVM domU",
+					"family": "Not Specified",
+					"manufacturer": "Xen",
+					"virtual_machine": true
+				},
+				"rhel_version": "8.4",
+				"release": "Red Hat Enterprise Linux release 8.4 (Ootpa)"
+			},
+			"hostname": "ip-172-31-25-176.ec2.internal",
+			"remote_branch": -1,
+			"remote_leaf": -1,
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee",
+			"product": "rhel",
+			"type": "host"
+		},
+		"reports": [{
+			"rule_id": "insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+			"component": "telemetry.rules.plugins.other.insights_core_egg_not_up2date.report",
+			"type": "rule",
+			"key": "INSIGHTS_CORE_EGG_NOT_UP2DATE",
+			"details": {
+				"rhel": "8.4",
+				"cur": "3.0.246-1",
+				"rel": "3.0.255",
+				"type": "rule",
+				"error_key": "INSIGHTS_CORE_EGG_NOT_UP2DATE"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4587"],
+				"kcs": ["https://access.redhat.com/articles/3747741"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "CVE_2021_33909_kernel|CVE_2021_33909",
+			"component": "prodsec.rules.CVE_2021_33909_kernel.report",
+			"type": "rule",
+			"key": "CVE_2021_33909",
+			"details": {
+				"kernel_package_name": "kernel",
+				"running_kernel": "4.18.0-305.el8",
+				"cves": {
+					"CVE-2021-33909": false
+				},
+				"type": "rule",
+				"error_key": "CVE_2021_33909"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2021-33909"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "xen_kdump_supported|XEN_KDUMP_SUPPORTED_V1",
+			"component": "telemetry.rules.plugins.aws.xen_kdump_supported.report",
+			"type": "rule",
+			"key": "XEN_KDUMP_SUPPORTED_V1",
+			"details": {
+				"rhel_version": "8.4",
+				"type": "rule",
+				"error_key": "XEN_KDUMP_SUPPORTED_V1"
+			},
+			"tags": ["xen", "rhel8", "aws", "rhel7", "rhel6"],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2890881"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3484", "https://projects.engineering.redhat.com/browse/CEECBA-4123", "https://issues.redhat.com/browse/CEECBA-5304"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1859233", "https://bugzilla.redhat.com/show_bug.cgi?id=1954906"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "empty_grubenv|EMPTY_GRUBENV_KERNELOPTS",
+			"component": "telemetry.rules.plugins.shells.empty_grubenv.report",
+			"type": "rule",
+			"key": "EMPTY_GRUBENV_KERNELOPTS",
+			"details": {
+				"boot_type": "BIOS",
+				"type": "rule",
+				"error_key": "EMPTY_GRUBENV_KERNELOPTS"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5897"],
+				"kcs": ["https://access.redhat.com/solutions/6488061"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2",
+			"component": "prodsec.rules.CVE_2018_3639_cpu_kernel.report",
+			"type": "rule",
+			"key": "CVE_2018_3639_CPU_BAD_MICROCODE_2",
+			"details": {
+				"vuln_file_present": true,
+				"cmd_avail": true,
+				"running_kernel": "4.18.0-305.el8.x86_64",
+				"rt": false,
+				"cloud_provider": "Amazon Web Services",
+				"virtualization": "xen",
+				"cves": {
+					"CVE-2018-3639": false
+				},
+				"type": "rule",
+				"error_key": "CVE_2018_3639_CPU_BAD_MICROCODE_2"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/ssbd"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1566890"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "ntp_leapsmear|NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+			"component": "telemetry.rules.plugins.service.ntp_leapsmear.report",
+			"type": "rule",
+			"key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+			"details": {
+				"smearing_servers": ["169.254.169.123"],
+				"smearing_patterns_len": 1,
+				"nonsmearing_servers": ["2.rhel.pool.ntp.org"],
+				"leap_directives": ["leapsectz right/UTC"],
+				"is_special_aws_ip_case": true,
+				"service": "chrony",
+				"type": "rule",
+				"error_key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/5132071"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3662", "https://projects.engineering.redhat.com/browse/CEECBA-4130"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+			"component": "prodsec.rules.CVE_2018_12130_cpu_kernel.report",
+			"type": "rule",
+			"key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+			"details": {
+				"rel": 8,
+				"vuln": ["Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown"],
+				"rt": false,
+				"cmd_any": false,
+				"cmdline_raw": "BOOT_IMAGE=(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64 root=UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585 ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+				"cmdline_dict": {
+					"BOOT_IMAGE": ["(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64"],
+					"root": ["UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585"],
+					"ro": [true],
+					"console": ["ttyS0,115200n8", "tty0"],
+					"net.ifnames": ["0"],
+					"rd.blacklist": ["nouveau"],
+					"nvme_core.io_timeout": ["4294967295"],
+					"crashkernel": ["auto"]
+				},
+				"rh6nosmt": false,
+				"rh6nosmt1st": false,
+				"dmesg_wrapped": false,
+				"cloud_provider": "Amazon Web Services",
+				"virtualization": "xen",
+				"cves": {
+					"CVE-2018-12126": false,
+					"CVE-2018-12130": false,
+					"CVE-2018-12127": false,
+					"CVE-2019-11091": false
+				},
+				"type": "rule",
+				"error_key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/mds"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1646784"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "ros_instance_evaluation|NO_PCP_DATA",
+			"component": "telemetry.rules.plugins.ros.ros_instance_evaluation.report_no_data",
+			"type": "rule",
+			"key": "NO_PCP_DATA",
+			"details": {
+				"rhel": "8.4",
+				"cloud_provider": "Amazon Web Services",
+				"instance_type": "t2.micro",
+				"type": "rule",
+				"error_key": "NO_PCP_DATA"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5875"],
+				"kcs": []
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"rule_id": "product_eol_check|AE_EOL_ERROR",
+			"component": "telemetry.rules.plugins.other.product_eol_check.report_ae",
+			"type": "rule",
+			"key": "AE_EOL_ERROR",
+			"details": {
+				"product": [{
+					"name": "Ansible Engine",
+					"version": "2.8",
+					"phase": "End of Life",
+					"eol": "2021-01-21",
+					"days": 343,
+					"policy": "https://access.redhat.com/support/policy/updates/ansible-engine"
+				}],
+				"brief": {
+					"Ansible Engine": "https://access.redhat.com/support/policy/updates/ansible-engine"
+				},
+				"type": "rule",
+				"error_key": "AE_EOL_ERROR"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-3825"],
+				"product_documentation": ["https://access.redhat.com/product-life-cycles", "https://access.redhat.com/support/policy/update_policies"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}],
+		"fingerprints": [],
+		"pass": [{
+			"pass_id": "CVE_2017_2636_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_2636_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-2636": "Vulnerable kernel not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/CVE-2017-2636"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1428319"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_0728_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_0728_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-0728": "The current running kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2132951"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1297475"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_7184_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_7184_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-7184": "The system is not running a vulnerable kernel."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1435153"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_5195_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_5195_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-5195": "The running kernel version is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2706661"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1384344"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_5696_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_5696_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-5696": "The running kernel version is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/challengeack"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1354708"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_passwd_perms|OK",
+			"component": "prodsec.rules.hardening_passwd_perms.report",
+			"type": "pass",
+			"key": "OK",
+			"details": {
+				"type": "pass",
+				"pass_key": "OK"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_1000405_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000405_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000405": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3253921"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1516514"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_14615_gpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_14615_gpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-14615": "Vulnerable module not loaded."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1789209"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_1000253_loadelf|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000253_loadelf.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000253": "Vulnerable kernel not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3189592"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1492212"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_0155_gpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_0155_gpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-0154": "Vulnerable module not loaded.",
+					"CVE-2019-0155": "Vulnerable module not loaded."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/i915-graphics"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1724393", "https://bugzilla.redhat.com/show_bug.cgi?id=1724398"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_6074_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_6074_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-6074": "Vulnerable kernel version is not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2934281"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1423071"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_systemd_writable|No systemd logs about world-writable unit files found.",
+			"component": "prodsec.rules.hardening_systemd_writable.report",
+			"type": "pass",
+			"key": "No systemd logs about world-writable unit files found.",
+			"details": {
+				"type": "pass",
+				"pass_key": "No systemd logs about world-writable unit files found."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4345951"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4894", "https://projects.engineering.redhat.com/browse/PSINSIGHTS-352"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_12653_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12653_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12653": "Vulnerable kernel module not installed.",
+					"CVE-2020-12654": "Vulnerable kernel module not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1831868", "https://bugzilla.redhat.com/show_bug.cgi?id=1832530"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_12657_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12657_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12657": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2020-12657"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_tls_key_perms|OK",
+			"component": "prodsec.rules.hardening_tls_key_perms.report",
+			"type": "pass",
+			"key": "OK",
+			"details": {
+				"type": "pass",
+				"pass_key": "OK"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_cryptopol_krb5|krb5 governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_krb5.report",
+			"type": "pass",
+			"key": "krb5 governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "krb5 governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_cryptopol_libssh|libssh governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_libssh.report",
+			"type": "pass",
+			"key": "libssh governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "libssh governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_11477_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_11477_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-11477": "Kernel is not vulnerable.",
+					"CVE-2019-11478": "Kernel is not vulnerable.",
+					"CVE-2019-11479": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": [""],
+				"bugzilla": ["https://bugzilla.redhat.com/1719123"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_1000251_kernel_blueborne|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000251_kernel_blueborne.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000251": "Vulnerable kernel not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/blueborne"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1489716"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_13077_wpa_supplicant|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_13077_wpa_supplicant.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-13077": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/kracks"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1491692"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_13272_kernel_ptrace|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_13272_kernel_ptrace.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-13272": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/4292201"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1730895"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_5461_nss|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_5461_nss.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-5461": "Vulnerable package(s) not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1440080"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_1000366_glibc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000366_glibc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000364": "Vulnerable kernel and glibc not running",
+					"CVE-2017-1000366": "Vulnerable kernel and glibc not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/stackguard"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1461333"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_1000368_sudo|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000368_sudo.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000368": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3059071"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459152"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_7494_samba|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_7494_samba.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-7494": "The system is not vulnerable, SELinux mitigates the issue"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3034621"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1450347"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2015_3456|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_3456.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-3456": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/1444903"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1218611"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_25661_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_25661_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-25661": "Kernel is not vulnerable.",
+					"CVE-2020-25662": "Kernel is not vulnerable.",
+					"CVE-2020-24490": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/BleedingTooth"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1891483", "https://bugzilla.redhat.com/show_bug.cgi?id=1891484", "https://bugzilla.redhat.com/show_bug.cgi?id=1888449"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_19788_polkit|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_19788_polkit.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-19788": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/25404"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1655925"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_25681_7_dnsmasq|Vulnerable package not installed.",
+			"component": "prodsec.rules.CVE_2020_25681_7_dnsmasq.report",
+			"type": "pass",
+			"key": "Vulnerable package not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Vulnerable package not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-001"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1881875", "https://bugzilla.redhat.com/show_bug.cgi?id=1882014", "https://bugzilla.redhat.com/show_bug.cgi?id=1882018", "https://bugzilla.redhat.com/show_bug.cgi?id=1889686", "https://bugzilla.redhat.com/show_bug.cgi?id=1889688", "https://bugzilla.redhat.com/show_bug.cgi?id=1890125", "https://bugzilla.redhat.com/show_bug.cgi?id=1891568"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_1112_glusterfs|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1112_glusterfs.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1112": "Vulnerable glusterfs-server-3.8.4-54.7 is not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3422521"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570891"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_12351_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12351_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12351": "Kernel is not vulnerable.",
+					"CVE-2020-12352": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/5493631"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1886521"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2015_7547_glibc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_7547_glibc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-7547": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2168451"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1293532"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_2315_24_git|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_2315_24_git.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-2315": "Vulnerable package not installed",
+					"CVE-2016-2324": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2201201"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1317981"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_2776_bind|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_2776_bind.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-2776": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1378380"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_3714_imagemagick|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_3714_imagemagick.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-3714": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/ImageTragick"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1332492"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_1000250_bluez|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000250_bluez.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000250": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1489446"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_12207_cpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_12207_cpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-12207": "Cannot detect this vulnerability in VM guest."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/ifu-page-mce"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1646768"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_14835_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_14835_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-14835": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/kernel-vhost"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1750727"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_11048_php|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_11048_php.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-11048": "HTTPD or NGINX web server is not installed or active"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_smbloris_samba|Vulnerable package not installed",
+			"component": "prodsec.rules.CVE_2017_smbloris_samba.report",
+			"type": "pass",
+			"key": "Vulnerable package not installed",
+			"details": {
+				"type": "pass",
+				"pass_key": "Vulnerable package not installed"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/smbloris"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1478016"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVEs_samba_badlock|All CVEs passed.",
+			"component": "prodsec.rules.CVEs_samba_badlock.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-2118": "The vulnerable samba version is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/badlock", "https://access.redhat.com/articles/2243351"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1317990"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "bash_injection|All CVEs passed.",
+			"component": "prodsec.rules.bash_injection.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2014-6271": "Vulnerable package not installed",
+					"CVE-2014-7169": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/1200223", "https://access.redhat.com/articles/1213683"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1141597", "https://bugzilla.redhat.com/show_bug.cgi?id=1146319"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_11135_cpu_taa|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_11135_cpu_taa.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-11135": "System is not vulnerable or is mitigated."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/tsx-asynchronousabort"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1753062"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "rpm_packages_checksum|rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches.",
+			"component": "prodsec.rules.rpm_packages_checksum.report",
+			"type": "pass",
+			"key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches.",
+			"details": {
+				"type": "pass",
+				"pass_key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2015_5600|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_5600.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-5600": "sshd settings not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1245969"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2015_7181_2_3_nss_nspr|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_7181_2_3_nss_nspr.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-7181": "Vulnerable package is not installed.",
+					"CVE-2015-7182": "Vulnerable package is not installed.",
+					"CVE-2015-7183": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2043623"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1269345", "https://bugzilla.redhat.com/show_bug.cgi?id=1269351", "https://bugzilla.redhat.com/show_bug.cgi?id=1269353"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_1002105_kubernetes|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1002105_kubernetes.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1002105": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3716411"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1648138"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2015_7501_commons_collections|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_7501_commons_collections.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-7501": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2045023"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1279330"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2021_3156_sudo|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2021_3156_sudo.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2021-3156": "The sudo package is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-002"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1917684"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_cryptopol_ssh_client|openssh-clients governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_ssh_client.report",
+			"type": "pass",
+			"key": "openssh-clients governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "openssh-clients governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_cryptopol_sshd|sshd governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_sshd.report",
+			"type": "pass",
+			"key": "sshd governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "sshd governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_14491_dnsmasq|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_14491_dnsmasq.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-14491": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3199382"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1495409"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_8897_kernel_popss|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_8897_kernel_popss.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-8897": "Vulnerable kernel version is not running",
+					"CVE-2018-1087": "Vulnerable kernel version is not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/pop_ss"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567074"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_5715_cpu_virt|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_5715_cpu_virt.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-5715": "The system is not exploitable because the relevant installed packages are not vulnerable and because the current combination and configuration of the CPU and kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/speculativeexecution"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519780"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_5753_4_cpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_5753_4_cpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-5753": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+					"CVE-2017-5715": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+					"CVE-2017-5754": "The current combination and configuration of the CPU and kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/speculativeexecution"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519778", "https://bugzilla.redhat.com/show_bug.cgi?id=1519781"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2021_30465_runc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2021_30465_runc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2021-30465": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-004"],
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2021-30465"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_3620_cpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_3620_cpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-3620": "Vulnerability file indicates system not vulnerable.",
+					"CVE-2018-3646": "Vulnerability file indicates system not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/L1TF"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1585005"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_12321_linux_firmware|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12321_linux_firmware.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12321": "linux-firmware is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2020-12321"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_14634_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_14634_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-14634": "System with less than 16GB RAM cannot be exploited"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/mutagen-astronomy"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1624498"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_1111_dhcp|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1111_dhcp.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1111": "Vulnerable config not detected"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3442151"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567974"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_14372_grub|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_14372_grub.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-14372": "The vulnerability is not applicable - system doesn't have Secure Boot enabled."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-003"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1873150"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVEs_Top10_2015_flash_plugin|All CVEs passed.",
+			"component": "prodsec.rules.CVEs_Top10_2015_flash_plugin.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-0359": "Firefox is not installed.",
+					"CVE-2015-5119": "Firefox is not installed.",
+					"CVE-2015-3113": "Firefox is not installed.",
+					"CVE-2015-5122": "Firefox is not installed.",
+					"CVE-2015-0311": "Firefox is not installed.",
+					"CVE-2015-3090": "Firefox is not installed.",
+					"CVE-2015-0336": "Firefox is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1188329", "https://bugzilla.redhat.com/show_bug.cgi?id=1211869", "https://bugzilla.redhat.com/show_bug.cgi?id=1240832", "https://bugzilla.redhat.com/show_bug.cgi?id=1235036", "https://bugzilla.redhat.com/show_bug.cgi?id=1242216", "https://bugzilla.redhat.com/show_bug.cgi?id=1185296", "https://bugzilla.redhat.com/show_bug.cgi?id=1221037", "https://bugzilla.redhat.com/show_bug.cgi?id=1201636"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2017_8779_rpc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_8779_rpc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-8779": "The system is not vulnerable, mitigation is applied"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3025811", "https://access.redhat.com/solutions/3053461"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1448124"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVEs_Top10_2016_flash_plugin|All CVEs passed.",
+			"component": "prodsec.rules.CVEs_Top10_2016_flash_plugin.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-1019": "Firefox is not installed.",
+					"CVE-2016-4117": "Firefox is not installed.",
+					"CVE-2015-8651": "Firefox is not installed.",
+					"CVE-2016-1010": "Firefox is not installed.",
+					"CVE-2015-8446": "Firefox is not installed.",
+					"CVE-2015-7645": "Firefox is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1324353", "https://bugzilla.redhat.com/show_bug.cgi?id=1335058", "https://bugzilla.redhat.com/show_bug.cgi?id=1397987", "https://bugzilla.redhat.com/show_bug.cgi?id=1316809", "https://bugzilla.redhat.com/show_bug.cgi?id=1289771", "https://bugzilla.redhat.com/show_bug.cgi?id=1271966"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_10713_grub|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_10713_grub.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-10713": "Vulnerable package versions not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/grub2bootloader"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1825243"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_1125_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_1125_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-1125": "Vulnerability file indicates system not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/4329821"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1724389"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "heartbleed|All CVEs passed.",
+			"component": "prodsec.rules.heartbleed.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2014-0160": "The vulnerable openssl version is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/781793"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1084875"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_0800_openssl_drown|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_0800_openssl_drown.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-0800": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2176731"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1310593"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_tls_nginx|Nginx service is not installed.",
+			"component": "prodsec.rules.hardening_tls_nginx.report",
+			"type": "pass",
+			"key": "Nginx service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Nginx service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2018_1000115_memcached|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1000115_memcached.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1000115": "memcached not accessible from external UDP connections"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3369081"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1551182"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_unencrypted_ntalk|Ntalk not in use or not available to public addresses.",
+			"component": "prodsec.rules.hardening_unencrypted_ntalk.report",
+			"type": "pass",
+			"key": "Ntalk not in use or not available to public addresses.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Ntalk not in use or not available to public addresses."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_ipv6_ip6tables|iptables is not installed.",
+			"component": "prodsec.rules.hardening_ipv6_ip6tables.report",
+			"type": "pass",
+			"key": "iptables is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "iptables is not installed."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_tls_satellite|Httpd service is not installed.",
+			"component": "prodsec.rules.hardening_tls_satellite.report",
+			"type": "pass",
+			"key": "Httpd service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Httpd service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/26833"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_unencrypted_rsh|Rsh not in use or not listening on public socket",
+			"component": "prodsec.rules.hardening_unencrypted_rsh.report",
+			"type": "pass",
+			"key": "Rsh not in use or not listening on public socket",
+			"details": {
+				"type": "pass",
+				"pass_key": "Rsh not in use or not listening on public socket"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_unsupported_xus|The system doesn't run EUS/AUS/TUS/E4S/ELS.",
+			"component": "prodsec.rules.hardening_unsupported_xus.report",
+			"type": "pass",
+			"key": "The system doesn't run EUS/AUS/TUS/E4S/ELS.",
+			"details": {
+				"type": "pass",
+				"pass_key": "The system doesn't run EUS/AUS/TUS/E4S/ELS."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/721513", "https://access.redhat.com/articles/4520991"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_tls_vsftpd|Vsftpd service is not installed.",
+			"component": "prodsec.rules.hardening_tls_vsftpd.report",
+			"type": "pass",
+			"key": "Vsftpd service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Vsftpd service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/3436", "https://access.redhat.com/solutions/1320473"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_tls_httpd|Httpd service is not installed.",
+			"component": "prodsec.rules.hardening_tls_httpd.report",
+			"type": "pass",
+			"key": "Httpd service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Httpd service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/26833"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_tls_dovecot|Dovecot service is not installed.",
+			"component": "prodsec.rules.hardening_tls_dovecot.report",
+			"type": "pass",
+			"key": "Dovecot service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Dovecot service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/120383", "https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_unsupported_zstream|The system runs supported non-EUS Z-Stream or can get latest updates via yum.",
+			"component": "prodsec.rules.hardening_unsupported_zstream.report",
+			"type": "pass",
+			"key": "The system runs supported non-EUS Z-Stream or can get latest updates via yum.",
+			"details": {
+				"type": "pass",
+				"pass_key": "The system runs supported non-EUS Z-Stream or can get latest updates via yum."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/238533", "https://access.redhat.com/solutions/2761031", "https://access.redhat.com/solutions/3433671"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_unencrypted_telnet|Telnet not in use or not listening on public socket.",
+			"component": "prodsec.rules.hardening_unencrypted_telnet.report",
+			"type": "pass",
+			"key": "Telnet not in use or not listening on public socket.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Telnet not in use or not listening on public socket."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_unencrypted_avahi|Avahi not in use.",
+			"component": "prodsec.rules.hardening_unencrypted_avahi.report",
+			"type": "pass",
+			"key": "Avahi not in use.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Avahi not in use."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_9490_httpd|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_9490_httpd.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-9490": "Vulnerable httpd version is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2020-9490"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2021_27365_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2021_27365_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2021-27365": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2021-27365"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "hardening_unencrypted_nis|NIS is not running or not available to public access.",
+			"component": "prodsec.rules.hardening_unencrypted_nis.report",
+			"type": "pass",
+			"key": "NIS is not running or not available to public access.",
+			"details": {
+				"type": "pass",
+				"pass_key": "NIS is not running or not available to public access."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2019_5736_runc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_5736_runc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-5736": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/runcescape"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1664908"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2016_9962_docker|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_9962_docker.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-9962": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/cve-2016-9962"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1409531"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_11100_haproxy|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_11100_haproxy.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-11100": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/haproxy"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1819111"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"pass_id": "CVE_2020_14298_docker|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_14298_docker.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-14298": "Vulnerable package not installed.",
+					"CVE-2020-14300": "Vulnerable package not installed.",
+					"CVE-2016-8867": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/runc-regression-docker-1.13.1-108"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1848239", "https://bugzilla.redhat.com/show_bug.cgi?id=1848829", "https://bugzilla.redhat.com/show_bug.cgi?id=1390163"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}],
+		"none": [{
+			"none_id": "network_vmxnet3_dropped_udp|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_dropped_udp.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/67823"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_randomized_vm|NONE_KEY",
+			"component": "prodsec.rules.hardening_randomized_vm.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/44460"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_grub|NONE_KEY",
+			"component": "prodsec.rules.hardening_grub.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_fstab|NONE_KEY",
+			"component": "prodsec.rules.hardening_fstab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/430253"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_max_uid|NONE_KEY",
+			"component": "prodsec.rules.hardening_max_uid.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/25404"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_browser_not_root|NONE_KEY",
+			"component": "prodsec.rules.hardening_browser_not_root.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2094931"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_logging_audit_max_log|NONE_KEY",
+			"component": "prodsec.rules.hardening_logging_audit_max_log.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_bridge_multicast_fail|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bridge_multicast_fail.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/361063", "https://access.redhat.com/solutions/784373"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1090670", "https://bugzilla.redhat.com/show_bug.cgi?id=1090749"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "net_source_routing_enabled|NONE_KEY",
+			"component": "prodsec.rules.net_source_routing_enabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/389853"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rport_delete_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.rport_delete_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1289833"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vfs_cache_pressure|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vfs_cache_pressure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/16995"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vm_min_free_kbytes_zero|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vm_min_free_kbytes_zero.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1727288"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2676"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_selinux_policy|NONE_KEY",
+			"component": "prodsec.rules.hardening_selinux_policy.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "overcommit|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.overcommit.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/55207"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4129", "https://issues.redhat.com/browse/CEECBA-4984"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "tcp_tw_race|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.tcp_tw_race.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1390823"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_yum|NONE_KEY",
+			"component": "prodsec.rules.hardening_yum.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nfs_mount_unresponsive_with_disabled_tcp_timestamps|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.nfs_mount_unresponsive_with_disabled_tcp_timestamps.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2338"],
+				"kcs": ["https://access.redhat.com/solutions/3060231"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459978", "https://bugzilla.redhat.com/show_bug.cgi?id=1472128", "https://bugzilla.redhat.com/show_bug.cgi?id=1479043"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "numa_perf_regression|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.numa_perf_regression.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/802693"],
+				"jira": []
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "storage_mlx5_srp_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.storage_mlx5_srp_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2189191"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhevh_binfmt_misc_module_missing|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhevh_binfmt_misc_module_missing.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2427351", "https://access.redhat.com/solutions/2853231"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "selinux_disabled_kernel_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.selinux_disabled_kernel_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4890471"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4701", "https://issues.redhat.com/browse/CEECBA-4962", "https://issues.redhat.com/browse/CEECBA-5240"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.1_release_notes/rhel-8_1_0_release#known-issue_security"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1778990"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "resolv_conf_over_three|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.resolv_conf_over_three.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/6407"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cifs_share_lost|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.cifs_share_lost.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/713373"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cifs_find_writable_file_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.cifs_find_writable_file_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2735"],
+				"kcs": ["https://access.redhat.com/solutions/2110301"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1295008", "https://bugzilla.redhat.com/show_bug.cgi?id=1577086"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_gpg_pubkey|NONE_KEY",
+			"component": "prodsec.rules.hardening_gpg_pubkey.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cifs_null_pointer_dereference|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.cifs_null_pointer_dereference.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3485421"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1591092", "https://bugzilla.redhat.com/show_bug.cgi?id=1609159"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_hang_hp_bl460c_g7|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hang_hp_bl460c_g7.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/257323"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "min_free_kbytes|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.min_free_kbytes.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-249", "https://projects.engineering.redhat.com/browse/CEECBA-3241"],
+				"kcs": ["https://access.redhat.com/solutions/336033"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hp_ilo4_nmi|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hp_ilo4_nmi.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/707563"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_hpasr|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hpasr.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/501543"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "alias_interface_invalid|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.alias_interface_invalid.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/21204"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nfs4_client_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nfs4_client_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2162441", "https://access.redhat.com/solutions/2685641"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_610_vxdmp_powerpath|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.kernel_panic_610_vxdmp_powerpath.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3676431"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_multiple_lo_ip_addr|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_multiple_lo_ip_addr.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2111561"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_nfs_stuck_syn_burst|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_nfs_stuck_syn_burst.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3018371"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "disabled_monitoring_bond|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.disabled_monitoring_bond.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/172483"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-320"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ip_fragment_packet_drop|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.ip_fragment_packet_drop.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1498603"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "audit_backlog_limit_exceeded_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.audit_backlog_limit_exceeded_panic.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/44602"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "incorrect_process_utimes|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.incorrect_process_utimes.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/185843"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "systemd_open_watchdog_nmi|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.systemd_open_watchdog_nmi.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1309033"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "qla2xxx_request_stuck|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.qla2xxx_request_stuck.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/189633"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_insufficient_tcp_page_allocation|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_insufficient_tcp_page_allocation.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2782"],
+				"kcs": ["https://access.redhat.com/solutions/4339681"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nfs4_delegation_infinite_loop|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.nfs4_delegation_infinite_loop.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/3164451"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459733"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "intel5500_interrupt_remapping_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.intel5500_interrupt_remapping_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-126"],
+				"kcs": ["https://access.redhat.com/solutions/110053"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=887006"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "tsc_rhel612_hung|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.tsc_rhel612_hung.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/60365"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "tsc_xeon_reboot_uptime|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.tsc_xeon_reboot_uptime.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/433883"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "bnx2fc_scan_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bnx2fc_scan_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/893403"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_slow_tcp_frto_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_slow_tcp_frto_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3658"],
+				"kcs": ["https://access.redhat.com/solutions/4978771"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1821522", "https://bugzilla.redhat.com/show_bug.cgi?id=1694860", "https://bugzilla.redhat.com/show_bug.cgi?id=1257096"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cciss_removed_on_rhel7|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.cciss_removed_on_rhel7.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/874443"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "dsa_filter_consumes_slab_objects|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.dsa_filter_consumes_slab_objects.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4518431"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2968"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nic_speed_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.nic_speed_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/111173"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-667", "https://issues.redhat.com/browse/CEECBA-5474"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_nfs_world_access|NONE_KEY",
+			"component": "prodsec.rules.hardening_nfs_world_access.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3069421"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "find_busiest_group_div_0|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.find_busiest_group_div_0.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/58609"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "veritas_reservation_conflict|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.veritas_reservation_conflict.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/55885"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_with_hardened_usercopy_due_to_splxmod|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_with_hardened_usercopy_due_to_splxmod.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3441"],
+				"kcs": ["https://access.redhat.com/solutions/3959371"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ovirt_node_upgrade_failure_if_selinux_is_disabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.ovirt_node_upgrade_failure_if_selinux_is_disabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["http://access.redhat.com/solutions/3346371"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519784", "https://bugzilla.redhat.com/show_bug.cgi?id=1542833"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "glibc_nssdb_miss_i686|NONE_KEY",
+			"component": "telemetry.rules.plugins.tools.glibc_nssdb_miss_i686.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1807824"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3654"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cpu_max_frequency_not_maitained|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.cpu_max_frequency_not_maitained.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2836"],
+				"kcs": ["https://access.redhat.com/solutions/2895271"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nic_start_failed_at_boot|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.nic_start_failed_at_boot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2523931"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "crash_in_memmap_init_zone|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.crash_in_memmap_init_zone.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3208581"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vm_swappiness_oom|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vm_swappiness_oom.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1149413"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_stuck_uio_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_stuck_uio_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5487"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1952952"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "freeipmi_reboot|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.freeipmi_reboot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/628963"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vpd_access_disabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vpd_access_disabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3077141"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "docker_deferred_remove|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_deferred_remove.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/2517781"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kpatch_induces_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kpatch_induces_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1845356"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3970"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "greenplum_database_hung|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.greenplum_database_hung.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2379961"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhev_host_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhev_host_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2985561"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ceph_kernel_client_append_write_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.ceph_kernel_client_append_write_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2329"],
+				"kcs": ["https://access.redhat.com/solutions/4254821"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1691227", "https://bugzilla.redhat.com/show_bug.cgi?id=1696594", "https://bugzilla.redhat.com/show_bug.cgi?id=1696595"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "docker_icc_false|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_icc_false.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2619411"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "crashkernel_with_3w_modules|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.crashkernel_with_3w_modules.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2335111"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_smbv1_client|NONE_KEY",
+			"component": "prodsec.rules.hardening_smbv1_client.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3164551"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vpd_rw_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vpd_rw_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/39748", "https://access.redhat.com/solutions/633553"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "docker_journald_stop|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_journald_stop.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2533421"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rename_network_interface|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.rename_network_interface.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1446773"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_monitor_separate_disk|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_monitor_separate_disk.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3428961"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "wrong_cores_after_offline|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.wrong_cores_after_offline.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3468711"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "irqbalance_invalid_parsing|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.irqbalance_invalid_parsing.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2842141"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1393539"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nfs_with_fscache_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.nfs_with_fscache_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2431"],
+				"kcs": ["https://access.redhat.com/solutions/2328681", "https://access.redhat.com/solutions/2439131"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_neigh_thresh3|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_neigh_thresh3.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984", "https://issues.redhat.com/browse/CEECBA-5276"],
+				"kcs": ["https://access.redhat.com/solutions/2789871"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "irqbalance_not_balancing|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.irqbalance_not_balancing.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/677073"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=987801"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "idm_ipa_server_openjdk_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.idm_ipa_server_openjdk_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4575"],
+				"kcs": ["https://access.redhat.com/solutions/5527751", "https://access.redhat.com/solutions/5529501"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1892216"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_ntp_not_enabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_ntp_not_enabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"product_documentation": ["https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-ntp-synchronization"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "page_allocation_error|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.page_allocation_error.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/90883"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nfs_mount_option_override_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.nfs_mount_option_override_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3547051"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1594707"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kvm_error_dev_shm_open_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.kvm_error_dev_shm_open_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2836251"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "leapp_upgrade_initramfs_missing|NONE_KEY",
+			"component": "telemetry.rules.plugins.leapp.leapp_upgrade_initramfs_missing.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5310"],
+				"kcs": ["https://access.redhat.com/solutions/6004981"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "isdn_hangup_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.isdn_hangup_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2374511"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "idm_ipv6_disabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.idm_ipv6_disabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3149991"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rebuild_initrd_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.rebuild_initrd_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/129173"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "megaraid_scsi_timeout_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.megaraid_scsi_timeout_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1787"],
+				"kcs": ["https://access.redhat.com/solutions/337313"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "pcc_cpufreq_driver_performance_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.pcc_cpufreq_driver_performance_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3804"],
+				"kcs": ["https://access.redhat.com/solutions/4379881", "https://access.redhat.com/solutions/3393161"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_at_d_real|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_at_d_real.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2537"],
+				"kcs": ["https://access.redhat.com/solutions/3248571"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "systemz_kdump_fail_with_devnode|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.systemz_kdump_fail_with_devnode.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/526113"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nproc_common_entries|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nproc_common_entries.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/146233"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "python_symlink_misconfiguration|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.python_symlink_misconfiguration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-3797"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1779294"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#python_versions", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#configuring-the-unversioned-python_installing-and-using-python"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_max_tries|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_max_tries.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_protocol|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_protocol.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_device_unregister_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_device_unregister_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3177471"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_startups|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_startups.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_manager_dhcp_client_network_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_dhcp_client_network_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4475"],
+				"kcs": ["https://access.redhat.com/solutions/5188461"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1843357"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "numa_node_mapping_255_cpus|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.numa_node_mapping_255_cpus.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1571393"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "pcc_cpufreq_fail_to_load|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.pcc_cpufreq_fail_to_load.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2546"],
+				"kcs": ["https://access.redhat.com/solutions/3421421"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_radix_tree_lookup_s390x|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_radix_tree_lookup_s390x.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2992"],
+				"kcs": ["https://access.redhat.com/solutions/4370121"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1725396"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhv_network_setup_failure_if_empty_line_in_ifcfg_files|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhv_network_setup_failure_if_empty_line_in_ifcfg_files.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2823131"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1406651"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nofile_set_to_unlimited_not_permitted|NONE_KEY",
+			"component": "telemetry.rules.plugins.shells.nofile_set_to_unlimited_not_permitted.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/33993"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4146"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vm_io_scheduler|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.vm_io_scheduler.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/5427"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_root_login|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_root_login.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ipa_client_short_hostname|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.ipa_client_short_hostname.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/200673"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3655"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_dhcp_connection_loss_nm_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_dhcp_connection_loss_nm_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2144"],
+				"kcs": ["https://access.redhat.com/solutions/1614093"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_manager_restart_fails_static_route|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_restart_fails_static_route.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2215901"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1302532"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_hugepages_allocation_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_hugepages_allocation_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/869233"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4247", "https://issues.redhat.com/browse/CEECBA-4566"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "pacemaker_corosync_service_status|NONE_KEY",
+			"component": "telemetry.rules.plugins.clusterha.pacemaker_corosync_service_status.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/905823"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "qlcnic_old_firmware|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.qlcnic_old_firmware.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1287363"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ansible_deprecated_repo|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.ansible_deprecated_repo.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3359651"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567750"],
+				"jira": []
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "btrfs_unsupported_rhel8|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.btrfs_unsupported_rhel8.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/197643"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1533904"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "systemd_system_would_hang_in_shutting_down|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.systemd_system_would_hang_in_shutting_down.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2277"],
+				"kcs": ["https://access.redhat.com/solutions/3181191"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1571098"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_dhcp_renew_lease_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_dhcp_renew_lease_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2236"],
+				"kcs": ["https://access.redhat.com/solutions/3672661"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_swap_on|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_swap_on.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3242331"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "race_in_kernel_sched_task_group|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.race_in_kernel_sched_task_group.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3085"],
+				"kcs": ["https://access.redhat.com/solutions/4621451"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "dnf_install_update_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.dnf_install_update_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3898"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1832869"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_sysctl_ipforward|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_sysctl_ipforward.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3586371"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhev_manager_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhev_manager_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2985561"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_hpsa|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hpsa.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/44870"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=698268", "https://bugzilla.redhat.com/show_bug.cgi?id=715397"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_hpwdt_rhvh_sys_reset|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hpwdt_rhvh_sys_reset.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3338821"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1491303"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3547"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhev_restart_libvirtd_after_stop_firewalld|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhev_restart_libvirtd_after_stop_firewalld.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2735671"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhev_vm_using_legacy_usb_devices|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhev_vm_using_legacy_usb_devices.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3054491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1443078"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vmw_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.vmw_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/639963"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-715"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vmware_guest_clock_unstable|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.vmware_guest_clock_unstable.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3215651"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rsyslog_memory_leak|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.rsyslog_memory_leak.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4502651"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3499"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1714094"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_kptr_restrict_value|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_kptr_restrict_value.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2634"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1704572"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vmware_slabinfo_nmi_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.vmware_slabinfo_nmi_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/23884"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-907"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhevm_not_able_to_clone_vm_snapshot|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhevm_not_able_to_clone_vm_snapshot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3205991"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1498478"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_large_lun_config|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_large_lun_config.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/1382643", "https://access.redhat.com/node/1480173"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1160104"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_bond1_not_working|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_bond1_not_working.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/262043"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_tuned_regression|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_tuned_regression.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2688", "https://issues.redhat.com/browse/CEECBA-5276"],
+				"kcs": ["https://access.redhat.com/solutions/4395931"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1739418"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_smbv1_server|NONE_KEY",
+			"component": "prodsec.rules.hardening_smbv1_server.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3164551"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_log_buf_len_consume|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_log_buf_len_consume.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1769173"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3041"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_firewall_zone_removed|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_firewall_zone_removed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2770321"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "df_hangs_inconsistent_data_mtab|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.df_hangs_inconsistent_data_mtab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3047"],
+				"kcs": ["https://access.redhat.com/solutions/3111191"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_hpsa_driver_phy_disk_pointer_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_hpsa_driver_phy_disk_pointer_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3485"],
+				"kcs": ["https://access.redhat.com/solutions/2112491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1334773", "https://bugzilla.redhat.com/show_bug.cgi?id=1334396", "https://bugzilla.redhat.com/show_bug.cgi?id=1335411", "https://bugzilla.redhat.com/show_bug.cgi?id=1334260"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "leap_smear_chronyd_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.leap_smear_chronyd_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2759021"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "df_used_negative|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.df_used_negative.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/17835"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "leapsec_system_hard_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.leapsec_system_hard_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/154713", "https://access.redhat.com/solutions/154793"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "abort_command_issued|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.abort_command_issued.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/27624"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_dnssec_2|NONE_KEY",
+			"component": "prodsec.rules.hardening_dnssec_2.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/54644"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "aio_max_nr_limit_reached|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.aio_max_nr_limit_reached.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/479623"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_flash|NONE_KEY",
+			"component": "prodsec.rules.hardening_flash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3756821"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cifs_mount_ver_issue_in_fstab|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.cifs_mount_ver_issue_in_fstab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3692491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1650148", "https://bugzilla.redhat.com/show_bug.cgi?id=1657841"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "load_nfsmod_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.load_nfsmod_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/2314491"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ipmi_list_corruption_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.ipmi_list_corruption_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2690791"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vxfs_mount_fail_selinux_policy|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.vxfs_mount_fail_selinux_policy.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3168651", "https://access.redhat.com/solutions/3886991"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_need_bonding_parameter|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_need_bonding_parameter.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/69510"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_bnx2x_firmware_rt_kernel|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bnx2x_firmware_rt_kernel.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2987451"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "mce_logs_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.mce_logs_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3160241"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_client_alive|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_client_alive.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hp_gen8_gen9_kvm_vm_not_start|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hp_gen8_gen9_kvm_vm_not_start.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3373571"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rx_crc_errors|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.rx_crc_errors.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/153413", "https://access.redhat.com/solutions/154543"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_config_perms|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_config_perms.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_iptables_services_fails|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_iptables_services_fails.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3138851"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_empty_passwords|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_empty_passwords.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "slow_performance_bgrt_mapping|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.slow_performance_bgrt_mapping.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3802481"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1481667"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_tab_key|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_tab_key.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/195653"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhnsd_pid_world_write|NONE_KEY",
+			"component": "telemetry.rules.plugins.sysmgmt.registration.rhnsd_pid_world_write.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3220971"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1480306"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ipv6_dev_route_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ipv6_dev_route_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2716"],
+				"kcs": ["https://access.redhat.com/solutions/4209461"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_grace_time|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_grace_time.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rhsm_daemon_segfaults_in_libnl_so|NONE_KEY",
+			"component": "telemetry.rules.plugins.sysmgmt.registration.rhsm_daemon_segfaults_in_libnl_so.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/623753"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5040"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_hang_hp_gen9|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hang_hp_gen9.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2797041"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "splunkd_memory_corruption|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.splunkd_memory_corruption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1382833"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vlan_mtu_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_mtu_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2162"],
+				"kcs": ["https://access.redhat.com/solutions/2888911"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1414186", "https://bugzilla.redhat.com/show_bug.cgi?id=1439166"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "subscription_cacert_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.sysmgmt.registration.subscription_cacert_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3261461"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4841"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "stack_corrupted_using_xfs|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.stack_corrupted_using_xfs.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/54544"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_manager_custom_mtu_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_custom_mtu_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2195741"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1303968"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "fs_resize2fs_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.fs_resize2fs_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-730", "https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/173543"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_etcd_watch_retry|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_etcd_watch_retry.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984", "https://issues.redhat.com/browse/CEECBA-5276"],
+				"kcs": ["https://access.redhat.com/solutions/3390441"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "missing_grub_symlink|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.missing_grub_symlink.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/770663"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "xinetd_per_source_limit|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.xinetd_per_source_limit.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-920", "https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/1312084", "https://access.redhat.com/solutions/186273"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hpsa_task_blocked|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hpsa_task_blocked.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1179703"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hugepage_over_reserved|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hugepage_over_reserved.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2116991"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "be2net_generate_pause_frames|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.be2net_generate_pause_frames.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/349783"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "pcp_logger_network_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.pcp.pcp_logger_network_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4865"],
+				"kcs": ["https://access.redhat.com/solutions/5394191"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1875659", "https://bugzilla.redhat.com/show_bug.cgi?id=1854035"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hugepage_race_condition_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hugepage_race_condition_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1992703"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nmi_switch_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nmi_switch_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/265173"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "vlan_interface_gateway|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.vlan_interface_gateway.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2171881"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1309899"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "no_ept_panic_with_l1tf|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.no_ept_panic_with_l1tf.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3570921"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ifdown_alias_interface|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.ifdown_alias_interface.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2099351"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ibm_power_broken_topology|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.ibm_power_broken_topology.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3669101"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1620038"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_initscripts_slave_config_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_initscripts_slave_config_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2952041"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1428574"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ilo|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.ilo.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/744973"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_logging_auditd|NONE_KEY",
+			"component": "prodsec.rules.hardening_logging_auditd.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "gfs_mount_option_lock_nolock_is_unsupported|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.gfs_mount_option_lock_nolock_is_unsupported.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2255"],
+				"kcs": ["https://access.redhat.com/solutions/2592671"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "infiniband_rdma_data_corruption|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.infiniband_rdma_data_corruption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4540"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1872424", "https://bugzilla.redhat.com/show_bug.cgi?id=1856158"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "start_lldpad_fcoe_cause_kernel_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.start_lldpad_fcoe_cause_kernel_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["http://access.redhat.com/solutions/3683051"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2470"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1353659", "https://bugzilla.redhat.com/show_bug.cgi?id=1656143", "https://bugzilla.redhat.com/show_bug.cgi?id=1656720"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_manager_arp_ip_address_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_manager_arp_ip_address_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3952491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1678796", "https://bugzilla.redhat.com/show_bug.cgi?id=1683092"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_logging_log_perms|NONE_KEY",
+			"component": "prodsec.rules.hardening_logging_log_perms.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "input_leds_soft_lockup|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.input_leds_soft_lockup.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3521341"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "neutron_openvswitch_agent_fail_with_ryu_key_error|NONE_KEY",
+			"component": "telemetry.rules.plugins.osp.neutron_openvswitch_agent_fail_with_ryu_key_error.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3128111"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "udev_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.udev_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2592401"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "thp_defrag_performance|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.thp_defrag_performance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/280443"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_manager_team_mac_address_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_manager_team_mac_address_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2158"],
+				"kcs": ["https://access.redhat.com/solutions/3372231"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1569924"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "multipathd_start_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.multipathd_start_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1394763"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "tsc_reboot_uptime|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.tsc_reboot_uptime.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/68466"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "storage_fnic_storage_offline|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.storage_fnic_storage_offline.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2162451"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4212"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nic_rx_perf_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.nic_rx_perf_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/20278"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_nfs|NONE_KEY",
+			"component": "prodsec.rules.hardening_nfs.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "intel_purley_skylake_supportable|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.intel_purley_skylake_supportable.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3135591"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "idm_smbv1_windows_unsupport|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.idm_smbv1_windows_unsupport.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3164551"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ipaddr_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ipaddr_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2785051"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1394500"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "storage_iscsi_without_netdev|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.storage_iscsi_without_netdev.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3889"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "sanity_check_fstab|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.sanity_check_fstab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/23769", "https://access.redhat.com/solutions/3109581"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3961"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_nfs_user_mountable|NONE_KEY",
+			"component": "prodsec.rules.hardening_nfs_user_mountable.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_with_cbsensor_module|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_with_cbsensor_module.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2929"],
+				"kcs": ["https://access.redhat.com/solutions/4544501"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "only_one_cpu_after_l1ft_udpate|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.only_one_cpu_after_l1ft_udpate.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3596941"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2525"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1623255"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_elasticsearch_pod_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_elasticsearch_pod_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4395531"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3459", "https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_udev_sfc_interface_name_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_udev_sfc_interface_name_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3134621"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_selinux_virtualization|NONE_KEY",
+			"component": "prodsec.rules.hardening_selinux_virtualization.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/6144012"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "fips_enabled_rngd_cpu_consumption|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.fips_enabled_rngd_cpu_consumption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4702"],
+				"kcs": ["https://access.redhat.com/solutions/5547981"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1884857"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "docker_daemon_huge_memory_usage|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_daemon_huge_memory_usage.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3223811"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_selinux_container|NONE_KEY",
+			"component": "prodsec.rules.hardening_selinux_container.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/6144032"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_rcu_threads_online_cpus|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_rcu_threads_online_cpus.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1404313"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1208895"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3169"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_sfc_nic_tx_timeout|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_sfc_nic_tx_timeout.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2190681"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4199"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "setup_netdev_packetdrop_params|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.setup_netdev_packetdrop_params.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1241943"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "stale_tcp_tg3|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.stale_tcp_tg3.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/624593"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-142"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "neighbour_table_overflow|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.neighbour_table_overflow.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/23454", "https://access.redhat.com/solutions/3588721"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_blue_flame|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_blue_flame.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/437113"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ifcfg_backup_conf_files|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ifcfg_backup_conf_files.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3950", "https://projects.engineering.redhat.com/browse/CEECBA-4114"],
+				"kcs": ["https://access.redhat.com/solutions/68127"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_bna_driver_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bna_driver_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2820921"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_team_slave_mac_address_diff|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_team_slave_mac_address_diff.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3402"],
+				"kcs": ["https://access.redhat.com/solutions/4065221"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1689774"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "corosync_heartbeat_bonding|NONE_KEY",
+			"component": "telemetry.rules.plugins.clusterha.corosync_heartbeat_bonding.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3068841", "https://access.redhat.com/solutions/27604"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3346"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "xen_netfront_packet_loss|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.xen_netfront_packet_loss.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2387391"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3480"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1348581"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ceph_increase_min_free_kbytes|NONE_KEY",
+			"component": "telemetry.rules.plugins.ceph.ceph_increase_min_free_kbytes.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2244"],
+				"kcs": ["https://access.redhat.com/solutions/3031521"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1704326"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_randome_usercopy|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_randome_usercopy.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4547651"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4254"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "snmp_memory_consumption_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.snmp_memory_consumption_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4409691"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1751195"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4458"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_manager_vlan_uuid_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_vlan_uuid_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3421371"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1553595"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "rpm_database_problems|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.rpm_database_problems.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1330653"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_vmware_guest_vmci_sock_transport|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_vmware_guest_vmci_sock_transport.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4757"],
+				"kcs": ["https://access.redhat.com/solutions/1582653"],
+				"bugzilla": ["https://bugzilla.redhat.com/1253971"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_mlx5_core_melanox_firmware_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_mlx5_core_melanox_firmware_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2975"],
+				"kcs": ["https://access.redhat.com/solutions/3122991"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1463367", "https://bugzilla.redhat.com/show_bug.cgi?id=1497604"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "mssql_sulogin_root_shell|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.mssql_sulogin_root_shell.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2421"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "aws_cloud_init_incorrectly_handles_multiple_authkeys|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_cloud_init_incorrectly_handles_multiple_authkeys.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3397", "https://issues.redhat.com/browse/CEECBA-4424"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1642008"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ocp_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3850", "https://issues.redhat.com/browse/CEECBA-5276"],
+				"product_documentation": ["https://docs.openshift.com/container-platform/3.11/install_config/redeploying_certificates.html"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "aws_cloud_init_overrides_local_network_config|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_cloud_init_overrides_local_network_config.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3442"],
+				"kcs": ["https://access.redhat.com/solutions/4350351"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1653131", "https://bugzilla.redhat.com/show_bug.cgi?id=1691685"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_cgroup_slabmem_leak_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_cgroup_slabmem_leak_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3291481"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4606"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1507149", "https://bugzilla.redhat.com/show_bug.cgi?id=1752421"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "aws_cloud_init_support_for_imdsv2|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_cloud_init_support_for_imdsv2.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3599", "https://projects.engineering.redhat.com/browse/CEECBA-4195", "https://issues.redhat.com/browse/CEECBA-4343"],
+				"kcs": ["https://access.redhat.com/solutions/4977371"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1803095", "https://bugzilla.redhat.com/show_bug.cgi?id=1803094", "https://bugzilla.redhat.com/show_bug.cgi?id=1827207", "https://bugzilla.redhat.com/show_bug.cgi?id=1866612", "https://bugzilla.redhat.com/show_bug.cgi?id=1869670"],
+				"product_documentation": ["https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "gnome_hangs_after_a_long_uptime|NONE_KEY",
+			"component": "telemetry.rules.plugins.desktop.gnome_hangs_after_a_long_uptime.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2925"],
+				"kcs": ["https://access.redhat.com/solutions/3556951"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "intel_sb_edac_driver_kernel_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.intel_sb_edac_driver_kernel_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3209"],
+				"kcs": ["https://access.redhat.com/solutions/2722761"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1353808"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "aws_vif_driver_mtu_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_vif_driver_mtu_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3578"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1502554"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_i40e_data_corruption_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_i40e_data_corruption_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2678"],
+				"kcs": ["https://access.redhat.com/solutions/3572961"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1404060", "https://bugzilla.redhat.com/show_bug.cgi?id=1413101"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cloud_init_fails_to_configure_network_device|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.cloud_init_fails_to_configure_network_device.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2927"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1602784"],
+				"changelog": ["https://code.launchpad.net/~otubo/cloud-init/+git/cloud-init/+merge/353436"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_i40e_mdd_detection_pf_reset|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_i40e_mdd_detection_pf_reset.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4385541"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4093"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cloud_init_local_service_delays_reboot|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.cloud_init_local_service_delays_reboot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3736", "https://projects.engineering.redhat.com/browse/CEECBA-4119"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1625874"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "oracle_tuned_profiles_oracle|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_tuned_profiles_oracle.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196298", "https://bugzilla.redhat.com/show_bug.cgi?id=1447323"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3753"],
+				"kcs": ["https://access.redhat.com/solutions/2867881"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_tcp_pkt_drp_alloc_fail|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_tcp_pkt_drp_alloc_fail.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3171", "https://projects.engineering.redhat.com/browse/CEECBA-3241"],
+				"kcs": ["https://access.redhat.com/solutions/4091971"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1696664", "https://bugzilla.redhat.com/show_bug.cgi?id=1704326"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_nfs_hostname_bnx2|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_nfs_hostname_bnx2.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/135843"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_bnx2x_link_down_driver_fw_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bnx2x_link_down_driver_fw_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/68961", "https://access.redhat.com/solutions/388813"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "failure_to_load_datasource|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.failure_to_load_datasource.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2813", "https://projects.engineering.redhat.com/browse/CEECBA-3510"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1738607"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "performance_impact_due_to_disabled_pcid_feature|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.performance_impact_due_to_disabled_pcid_feature.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3987"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1691421", "https://bugzilla.redhat.com/show_bug.cgi?id=1697940"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "slowness_console_aspeed_grahics_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.slowness_console_aspeed_grahics_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3664"],
+				"kcs": ["https://access.redhat.com/solutions/4545311"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1780145", "https://bugzilla.redhat.com/show_bug.cgi?id=1780146", "https://bugzilla.redhat.com/show_bug.cgi?id=1780147", "https://bugzilla.redhat.com/show_bug.cgi?id=1739623"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_on_azure|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.kdump_on_azure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2179"],
+				"kcs": ["https://access.redhat.com/solutions/3091051"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_iwlwifi_driver_sysctl_conf_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_iwlwifi_driver_sysctl_conf_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3618"],
+				"kcs": ["https://access.redhat.com/solutions/4205041"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1718118"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "mail_files_left|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.mail_files_left.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/258603"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_target_available_memory_size|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_target_available_memory_size.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4303", "https://issues.redhat.com/browse/CEECBA-4967", "https://issues.redhat.com/browse/CEECBA-5255"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1868698"],
+				"kcs": ["https://access.redhat.com/articles/5676371"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "performance_impact_on_hyperv_vm_using_hv_netvsc_interface|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.performance_impact_on_hyperv_vm_using_hv_netvsc_interface.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4975221"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3866", "https://issues.redhat.com/browse/CEECBA-4984"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1821814", "https://bugzilla.redhat.com/show_bug.cgi?id=1838600"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "pkla_check_authorization_process_task_uninterruptible_or_defunct|NONE_KEY",
+			"component": "telemetry.rules.plugins.shells.pkla_check_authorization_process_task_uninterruptible_or_defunct.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3213721"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570907"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2539", "https://issues.redhat.com/browse/CEECBA-4382"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ixgbevf_networking_enhance|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.ixgbevf_networking_enhance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2740491"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4120"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1274175"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "unable_to_reset_password_on_rhel8_azure|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.unable_to_reset_password_on_rhel8_azure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": ["azure", "rhel8"],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2804"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1708040"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "support_for_next_gen_arm_instances|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.support_for_next_gen_arm_instances.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3765"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1770979"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_mlx5_infiniband_drv_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_mlx5_infiniband_drv_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4700", "https://issues.redhat.com/browse/CEECBA-5130"],
+				"kcs": ["https://access.redhat.com/solutions/5601811"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1880184", "https://bugzilla.redhat.com/show_bug.cgi?id=1789380"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "be2net_dropped_large_packets|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.be2net_dropped_large_packets.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/659453"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-524"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_qlcnic_interface_hang_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_qlcnic_interface_hang_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2354511"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3337"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1403143", "https://bugzilla.redhat.com/show_bug.cgi?id=1342659"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "nmi_dazed_and_confused|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nmi_dazed_and_confused.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/35402", "https://access.redhat.com/solutions/26467"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "ethernet_amd_epyc_iommu_performance_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.ethernet_amd_epyc_iommu_performance_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2521"],
+				"kcs": ["https://access.redhat.com/solutions/3237861"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1508644", "https://bugzilla.redhat.com/show_bug.cgi?id=1531456"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hyperv_guest_set_mtu_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hyperv_guest_set_mtu_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2705511"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "unsupported_journal_mode|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.unsupported_journal_mode.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4938"],
+				"kcs": ["https://access.redhat.com/solutions/358963", "https://access.redhat.com/solutions/424073"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hypervisor_bridge_bonding_mode|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.hypervisor_bridge_bonding_mode.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1045"],
+				"kcs": ["https://access.redhat.com/solutions/67546"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ovs_vxlan_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ovs_vxlan_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2938"],
+				"kcs": ["https://access.redhat.com/solutions/4280441"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_infiniband_ipoib_crash_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_infiniband_ipoib_crash_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3465401"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vmxnet3_interface_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_interface_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2837431"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "oracle_cluster_avahi_daemon|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_cluster_avahi_daemon.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/25463"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-144", "https://issues.redhat.com/browse/CEECBA-4633"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_intel_nic_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_intel_nic_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/119653"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4317"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "networking_lvs_slow_performance|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.networking_lvs_slow_performance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/92973"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "oracle_db_ps_fail_no_buff_mem|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_db_ps_fail_no_buff_mem.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2945981"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3989"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "aws_microcode_loaded|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_microcode_loaded.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3170"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1716333"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "osp_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.osp.osp_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2942211"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "neutron_osp11_ha_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.osp.neutron_osp11_ha_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1461110", "https://bugzilla.redhat.com/show_bug.cgi?id=1461111", "https://bugzilla.redhat.com/show_bug.cgi?id=1461113"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_hv_netvsc_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2531"],
+				"kcs": ["https://access.redhat.com/solutions/3949321"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1661632", "https://bugzilla.redhat.com/show_bug.cgi?id=1679997"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "tg3_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.tg3_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1834"],
+				"kcs": ["https://access.redhat.com/solutions/69382"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_packet_drop_cisco_vic_enic_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_packet_drop_cisco_vic_enic_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/387813"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4542"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_hv_netvsc_driver_ring_buffer_signal_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_driver_ring_buffer_signal_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2689"],
+				"kcs": ["https://access.redhat.com/solutions/3489351"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1591976", "https://bugzilla.redhat.com/show_bug.cgi?id=1605089"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "be2net_mccq|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.be2net_mccq.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/35572", "https://access.redhat.com/solutions/60857"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "cannot_update_rhv_manager_due_to_ansible_version_conflict|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.cannot_update_rhv_manager_due_to_ansible_version_conflict.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4639"],
+				"kcs": ["https://access.redhat.com/solutions/5480561"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1887268", "https://bugzilla.redhat.com/show_bug.cgi?id=1887142"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "qlcnic_driver_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.qlcnic_driver_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/916883"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_rt_kernel_panic_interrupt_context_preemption|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_rt_kernel_panic_interrupt_context_preemption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2552"],
+				"kcs": ["https://access.redhat.com/solutions/3061081"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1402121", "https://bugzilla.redhat.com/show_bug.cgi?id=1402837", "https://bugzilla.redhat.com/show_bug.cgi?id=1401779"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "crashkernel_reservation_value|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.crashkernel_reservation_value.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3483431", "https://access.redhat.com/solutions/916043", "https://access.redhat.com/solutions/3698411", "https://access.redhat.com/solutions/1186753"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3863", "https://issues.redhat.com/browse/CEECBA-4381", "https://issues.redhat.com/browse/CEECBA-5671"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/supported-kdump-configurations-and-targets_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_i40e_firmware_offload_support|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_i40e_firmware_offload_support.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2943651"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "panic_be2net_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.panic_be2net_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/60123"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_matrox_vga_legacy_bios_mgag200_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_matrox_vga_legacy_bios_mgag200_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4903"],
+				"kcs": ["https://access.redhat.com/solutions/5770681", "https://access.redhat.com/solutions/4639181"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1913519"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "insights_client_core_collection|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.insights_client_core_collection.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5042"],
+				"kcs": ["https://access.redhat.com/articles/5699071"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vlan_corrupt_traffic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_corrupt_traffic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2966631"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_hv_netvsc_drv_miss_tx_queue_wakeup|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_drv_miss_tx_queue_wakeup.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2879", "https://issues.redhat.com/browse/CEECBA-4401"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1841900", "https://bugzilla.redhat.com/show_bug.cgi?id=1781322", "https://bugzilla.redhat.com/show_bug.cgi?id=1774687", "https://bugzilla.redhat.com/show_bug.cgi?id=1842485"],
+				"kcs": ["https://access.redhat.com/solutions/5189981"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "oracle_tuning|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_tuning.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/39188"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-233", "https://projects.engineering.redhat.com/browse/CEECBA-3830"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vmxnet3_discard_ipv6|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_discard_ipv6.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2987791"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "high_latency_issue_with_hv_netvsc_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.high_latency_issue_with_hv_netvsc_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3604", "https://projects.engineering.redhat.com/browse/CEECBA-4010"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1805950", "https://bugzilla.redhat.com/show_bug.cgi?id=1848130"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ifb_checksum_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ifb_checksum_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3425461"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-3501"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "CVE_2021_38647_omi|NONE_KEY",
+			"component": "prodsec.rules.CVE_2021_38647_omi.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vxlan_panic_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vxlan_panic_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2777"],
+				"kcs": ["https://access.redhat.com/solutions/3734801"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_bnx2x_ptp_kernel_panic_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bnx2x_ptp_kernel_panic_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3007"],
+				"kcs": ["https://access.redhat.com/solutions/3192002"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1344743", "https://bugzilla.redhat.com/show_bug.cgi?id=1518669"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vmxnet3_driver_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_driver_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2662661"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "systemd_non_persistent_ifname|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.systemd_non_persistent_ifname.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4357"],
+				"kcs": ["https://access.redhat.com/solutions/2435891", "https://access.redhat.com/solutions/283233"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1520983", "https://bugzilla.redhat.com/show_bug.cgi?id=1793974", "https://bugzilla.redhat.com/show_bug.cgi?id=1859926"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_third_party_drivers|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_third_party_drivers.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4304"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/installing-and-configuring-kdump_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1879558"],
+				"kcs": ["https://access.redhat.com/articles/5679941"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_veth_corrupt_pkt_application|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_veth_corrupt_pkt_application.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2140"],
+				"kcs": ["https://access.redhat.com/solutions/2173981"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vlan_offloading_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_offloading_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3658131"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1640645"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ixgbe_nic_reset|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ixgbe_nic_reset.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2070703"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4062"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "oracle_storage_tuning|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_storage_tuning.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2607861"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3829"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ixgbe_nic_intel_X550_performance_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ixgbe_nic_intel_X550_performance_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3243"],
+				"kcs": ["https://access.redhat.com/solutions/4636801"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1781429"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "missing_boot_files|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.missing_boot_files.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/369233"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_cisco_VIC_irq_imbalance|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_cisco_VIC_irq_imbalance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2167"],
+				"kcs": ["https://access.redhat.com/solutions/4126461"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "selinux_selinuxtype|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.selinux_selinuxtype.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/232483", "https://access.redhat.com/solutions/6062341"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5466", "https://projects.engineering.redhat.com/browse/CEECBA-641"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_nvidia_nouveau_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_nvidia_nouveau_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3378"],
+				"kcs": ["https://access.redhat.com/solutions/2990791"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1449338"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_xen_pv_guest_fails|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_xen_pv_guest_fails.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3115"],
+				"kcs": ["https://access.redhat.com/solutions/3544391"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1487754"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_qlogic_qede_nic_init_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_qlogic_qede_nic_init_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3720331"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_crash_at_shpc_probe|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.kernel_crash_at_shpc_probe.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2672", "https://issues.redhat.com/browse/CEECBA-5193"],
+				"kcs": ["https://access.redhat.com/solutions/3688401"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kernel_panic_uefi_boot_loader_nopti_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_uefi_boot_loader_nopti_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3314"],
+				"kcs": ["https://access.redhat.com/solutions/4214721"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1540061", "https://bugzilla.redhat.com/show_bug.cgi?id=1565700"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_nic_i40e_i40evf_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_nic_i40e_i40evf_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2937"],
+				"kcs": ["https://access.redhat.com/solutions/3753111"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1722774", "https://bugzilla.redhat.com/show_bug.cgi?id=1454890"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "oracle_java_se_access_not_available|NONE_KEY",
+			"component": "telemetry.rules.plugins.java.oracle_java_se_access_not_available.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3253281", "https://access.redhat.com/solutions/732883"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_ibmvnic_driver_kernel_panic_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ibmvnic_driver_kernel_panic_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3769"],
+				"kcs": ["https://access.redhat.com/solutions/5059441"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1783775", "https://bugzilla.redhat.com/show_bug.cgi?id=1828708"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "check_debugshell|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.check_debugshell.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2397"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "xen_pv_guest_boot_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.xen_pv_guest_boot_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3307791"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1531294"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3478", "https://projects.engineering.redhat.com/browse/CEECBA-4305"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "xen_pv_guest_panic_with_eagerfpu|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.xen_pv_guest_panic_with_eagerfpu.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3551871"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "el7_to_el8_upgrade|NONE_KEY",
+			"component": "telemetry.rules.plugins.leapp.el7_to_el8_upgrade.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3199", "https://issues.redhat.com/browse/CEECBA-4533", "https://issues.redhat.com/browse/CEECBA-3792", "https://issues.redhat.com/browse/CEECBA-4677", "https://issues.redhat.com/browse/CEECBA-5079", "https://issues.redhat.com/browse/CEECBA-5294"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index"],
+				"kcs": ["https://access.redhat.com/solutions/4120411", "https://access.redhat.com/solutions/4824451", "https://access.redhat.com/solutions/5154031"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_vlan_i40e_driver_offloading_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_i40e_driver_offloading_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2797"],
+				"kcs": ["https://access.redhat.com/solutions/3662011"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1589450"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_lpfc_be2net_nic_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_lpfc_be2net_nic_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2224"],
+				"kcs": ["https://access.redhat.com/solutions/3964901"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1657981", "https://bugzilla.redhat.com/show_bug.cgi?id=1683908"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "kdump_iommu|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_iommu.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/69019"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-457"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_intel_uhd_graphic_network_card_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_intel_uhd_graphic_network_card_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3013"],
+				"kcs": ["https://access.redhat.com/solutions/4154511"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1711234"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hpdsa_version_incompatible|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hpdsa_version_incompatible.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3337891"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "network_team_bond_slave_be2net_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_team_bond_slave_be2net_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2611"],
+				"kcs": ["https://access.redhat.com/solutions/2328621"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1337318", "https://bugzilla.redhat.com/show_bug.cgi?id=1382354"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "fc_hba_init_failure_during_boot|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.fc_hba_init_failure_during_boot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3421081"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570785", "https://bugzilla.redhat.com/show_bug.cgi?id=1584377", "https://bugzilla.redhat.com/show_bug.cgi?id=1657981"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "aws_kdump_boot_stuck_specific_instance_type|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_kdump_boot_stuck_specific_instance_type.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4054"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1844522"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_httpd_virtualhost|NONE_KEY",
+			"component": "prodsec.rules.hardening_httpd_virtualhost.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3022811"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}, {
+			"none_id": "hardening_ssh_hmac_cipher|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_hmac_cipher.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/420283https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "0b6cf763-ea84-4961-a015-5b948b1366ee"
+		}],
+		"analysis_metadata": {
+			"start": "2021-12-29T08:13:07.050409+00:00",
+			"finish": "2021-12-29T08:13:08.507888+00:00",
+			"execution_context": "insights.core.context.SerializedArchiveContext",
+			"plugin_sets": {
+				"insights-core": {
+					"version": "insights-core-3.0.254-1",
+					"commit": "placeholder"
+				},
+				"insights-plugins": {
+					"version": "insights-plugins-2.0.200-1",
+					"commit": "placeholder"
+				},
+				"insights-prodsec-rules": {
+					"version": "insights-prodsec-rules-1.0.133-1",
+					"commit": "placeholder"
+				}
+			}
+		}
+	}
+}

--- a/sample-files/insights-engine-result-optimized.json
+++ b/sample-files/insights-engine-result-optimized.json
@@ -1,0 +1,6367 @@
+{
+    "input": {
+        "platform_metadata": {
+            "account": "0000001",
+            "b64_identity": "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMSIsInR5cGUiOiAiVXNlciIsInVzZXIiOiB7InVzZXJuYW1lIjogInR1c2VyQHJlZGhhdC5jb20iLCJlbWFpbCI6ICJ0dXNlckByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6ICJ0ZXN0IiwibGFzdF9uYW1lIjogInVzZXIiLCJpc19hY3RpdmUiOiB0cnVlLCJpc19vcmdfYWRtaW4iOiBmYWxzZSwgImlzX2ludGVybmFsIjogdHJ1ZSwgImxvY2FsZSI6ICJlbl9VUyJ9LCJpbnRlcm5hbCI6IHsgIm9yZ19pZCI6ICIwMDAwMDEifX19Cg==",
+            "category": "collection",
+            "elapsed_time": 1640760773.5824873,
+            "extras": {},
+            "host": {},
+            "id": null,
+            "metadata": {
+                "reporter": "",
+                "stale_timestamp": "0001-01-01T00:00:00Z"
+            },
+            "payload_id": null,
+            "principal": "000001",
+            "request_id": "f77010e80955/miYkbDetAo-000004",
+            "satellite_managed": null,
+            "service": "advisor",
+            "size": 191765,
+            "timestamp": "2021-12-29T06:52:52.553450962Z",
+            "url": "http://minio:9000/insights-upload-perma/f77010e80955/miYkbDetAo-000004?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211229%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211229T065252Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=9d0f37a4d72eb5f54ad17ceff31275783332b63e52853bc00c224ba838d27a75",
+            "validation": null,
+            "test": null,
+            "is_ros": "true"
+        },
+        "metadata": {
+            "request_id": "f77010e80955/miYkbDetAo-000004"
+        },
+        "host": {
+            "bios_uuid": "ec2a41e3-6b3f-03a5-9fbf-4df10824bb56",
+            "satellite_id": null,
+            "subscription_manager_id": "a5da0f02-8bc5-4064-83f7-f8ff8caafcd6",
+            "stale_warning_timestamp": "2022-01-06T11:52:53.911645+00:00",
+            "per_reporter_staleness": {
+                "puptoo": {
+                    "last_check_in": "2021-12-29T06:52:54.145975+00:00",
+                    "stale_timestamp": "2021-12-30T11:52:53.911645+00:00",
+                    "check_in_succeeded": true
+                }
+            },
+            "fqdn": "ip-10-0-60-207.ap-northeast-1.compute.internal",
+            "system_profile": {
+                "os_release": "8.4",
+                "os_kernel_version": "4.18.0",
+                "satellite_managed": false
+            },
+            "ip_addresses": ["10.0.60.207"],
+            "created": "2021-12-17T18:54:25.116236+00:00",
+            "updated": "2021-12-29T06:52:54.146814+00:00",
+            "reporter": "puptoo",
+            "culled_timestamp": "2022-01-13T11:52:53.911645+00:00",
+            "id": "ec0c5922-19cf-457e-9d8d-a95ec69fb729",
+            "rhel_machine_id": null,
+            "display_name": "ip-10-0-60-207.ap-northeast-1.compute.internal",
+            "stale_timestamp": "2021-12-30T11:52:53.911645+00:00",
+            "insights_id": "5e71b703-4789-4564-8dff-590f57a14525",
+            "account": "0000001",
+            "provider_type": null,
+            "tags": [],
+            "provider_id": null,
+            "ansible_host": null,
+            "mac_addresses": ["0e:85:30:fe:02:af", "00:00:00:00:00:00"]
+        },
+        "type": "updated",
+        "timestamp": "2021-12-29T06:52:54.155265+00:00"
+    },
+    "results": {
+        "system": {
+            "metadata": {
+                "timezone_information": {
+                    "utcoffset": 0,
+                    "timezone": "UTC"
+                },
+                "bios_information": {
+                    "bios_revision": "4.2",
+                    "release_date": "08/24/2006",
+                    "vendor": "Xen",
+                    "version": "4.2.amazon"
+                },
+                "system_information": {
+                    "product_name": "HVM domU",
+                    "family": "Not Specified",
+                    "manufacturer": "Xen",
+                    "virtual_machine": true
+                },
+                "rhel_version": "8.4",
+                "cpu_utilization": "50",
+                "mem_utilization": "36",
+                "io_utilization": {
+                    "xvda": "0.314"
+                },
+                "release": "Red Hat Enterprise Linux release 8.4 (Ootpa)"
+            },
+            "hostname": "ip-10-0-60-207.ap-northeast-1.compute.internal",
+            "remote_branch": -1,
+            "remote_leaf": -1,
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525",
+            "product": "rhel",
+            "type": "host"
+        },
+        "reports": [{
+            "rule_id": "insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+            "component": "telemetry.rules.plugins.other.insights_core_egg_not_up2date.report",
+            "type": "rule",
+            "key": "INSIGHTS_CORE_EGG_NOT_UP2DATE",
+            "details": {
+                "rhel": "8.4",
+                "cur": "3.0.253-1",
+                "rel": "3.0.255",
+                "type": "rule",
+                "error_key": "INSIGHTS_CORE_EGG_NOT_UP2DATE"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4587"],
+                "kcs": ["https://access.redhat.com/articles/3747741"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "rule_id": "CVE_2021_33909_kernel|CVE_2021_33909",
+            "component": "prodsec.rules.CVE_2021_33909_kernel.report",
+            "type": "rule",
+            "key": "CVE_2021_33909",
+            "details": {
+                "kernel_package_name": "kernel",
+                "running_kernel": "4.18.0-305.el8",
+                "cves": {
+                    "CVE-2021-33909": false
+                },
+                "type": "rule",
+                "error_key": "CVE_2021_33909"
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/CVE-2021-33909"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "rule_id": "xen_kdump_supported|XEN_KDUMP_SUPPORTED_V1",
+            "component": "telemetry.rules.plugins.aws.xen_kdump_supported.report",
+            "type": "rule",
+            "key": "XEN_KDUMP_SUPPORTED_V1",
+            "details": {
+                "rhel_version": "8.4",
+                "type": "rule",
+                "error_key": "XEN_KDUMP_SUPPORTED_V1"
+            },
+            "tags": ["xen", "rhel8", "aws", "rhel7", "rhel6"],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2890881"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3484", "https://projects.engineering.redhat.com/browse/CEECBA-4123", "https://issues.redhat.com/browse/CEECBA-5304"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1859233", "https://bugzilla.redhat.com/show_bug.cgi?id=1954906"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "rule_id": "CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2",
+            "component": "prodsec.rules.CVE_2018_3639_cpu_kernel.report",
+            "type": "rule",
+            "key": "CVE_2018_3639_CPU_BAD_MICROCODE_2",
+            "details": {
+                "vuln_file_present": true,
+                "cmd_avail": true,
+                "running_kernel": "4.18.0-305.el8.x86_64",
+                "rt": false,
+                "cloud_provider": "Amazon Web Services",
+                "virtualization": "xen",
+                "cves": {
+                    "CVE-2018-3639": false
+                },
+                "type": "rule",
+                "error_key": "CVE_2018_3639_CPU_BAD_MICROCODE_2"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/ssbd"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1566890"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "rule_id": "ntp_leapsmear|NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+            "component": "telemetry.rules.plugins.service.ntp_leapsmear.report",
+            "type": "rule",
+            "key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+            "details": {
+                "smearing_servers": ["169.254.169.123"],
+                "smearing_patterns_len": 1,
+                "nonsmearing_servers": ["2.rhel.pool.ntp.org"],
+                "leap_directives": ["leapsectz right/UTC"],
+                "is_special_aws_ip_case": true,
+                "service": "chrony",
+                "type": "rule",
+                "error_key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/5132071"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3662", "https://projects.engineering.redhat.com/browse/CEECBA-4130"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "rule_id": "CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+            "component": "prodsec.rules.CVE_2018_12130_cpu_kernel.report",
+            "type": "rule",
+            "key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+            "details": {
+                "rel": 8,
+                "vuln": ["Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown"],
+                "rt": false,
+                "cmd_any": false,
+                "cmdline_raw": "BOOT_IMAGE=(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64 root=UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585 ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto psi=1",
+                "cmdline_dict": {
+                    "BOOT_IMAGE": ["(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64"],
+                    "root": ["UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585"],
+                    "ro": [true],
+                    "console": ["ttyS0,115200n8", "tty0"],
+                    "net.ifnames": ["0"],
+                    "rd.blacklist": ["nouveau"],
+                    "nvme_core.io_timeout": ["4294967295"],
+                    "crashkernel": ["auto"],
+                    "psi": ["1"]
+                },
+                "rh6nosmt": false,
+                "rh6nosmt1st": false,
+                "dmesg_wrapped": false,
+                "cloud_provider": "Amazon Web Services",
+                "virtualization": "xen",
+                "cves": {
+                    "CVE-2018-12126": false,
+                    "CVE-2018-12130": false,
+                    "CVE-2018-12127": false,
+                    "CVE-2019-11091": false
+                },
+                "type": "rule",
+                "error_key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/mds"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1646784"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }],
+        "fingerprints": [],
+        "pass": [{
+            "pass_id": "CVE_2017_2636_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_2636_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-2636": "Vulnerable kernel not running"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/CVE-2017-2636"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1428319"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_0728_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_0728_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-0728": "The current running kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/2132951"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1297475"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_7184_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_7184_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-7184": "The system is not running a vulnerable kernel."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1435153"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_5195_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_5195_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-5195": "The running kernel version is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/2706661"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1384344"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_5696_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_5696_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-5696": "The running kernel version is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/challengeack"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1354708"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_passwd_perms|OK",
+            "component": "prodsec.rules.hardening_passwd_perms.report",
+            "type": "pass",
+            "key": "OK",
+            "details": {
+                "type": "pass",
+                "pass_key": "OK"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_1000405_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_1000405_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-1000405": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/3253921"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1516514"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_14615_gpu_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_14615_gpu_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-14615": "Vulnerable module not loaded."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1789209"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_1000253_loadelf|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_1000253_loadelf.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-1000253": "Vulnerable kernel not running"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/3189592"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1492212"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_0155_gpu_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_0155_gpu_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-0154": "Vulnerable module not loaded.",
+                    "CVE-2019-0155": "Vulnerable module not loaded."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/i915-graphics"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1724393", "https://bugzilla.redhat.com/show_bug.cgi?id=1724398"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_6074_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_6074_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-6074": "Vulnerable kernel version is not running"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/2934281"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1423071"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_systemd_writable|No systemd logs about world-writable unit files found.",
+            "component": "prodsec.rules.hardening_systemd_writable.report",
+            "type": "pass",
+            "key": "No systemd logs about world-writable unit files found.",
+            "details": {
+                "type": "pass",
+                "pass_key": "No systemd logs about world-writable unit files found."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/4345951"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4894", "https://projects.engineering.redhat.com/browse/PSINSIGHTS-352"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_12653_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_12653_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-12653": "Vulnerable kernel module not installed.",
+                    "CVE-2020-12654": "Vulnerable kernel module not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1831868", "https://bugzilla.redhat.com/show_bug.cgi?id=1832530"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_12657_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_12657_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-12657": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/CVE-2020-12657"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_tls_key_perms|OK",
+            "component": "prodsec.rules.hardening_tls_key_perms.report",
+            "type": "pass",
+            "key": "OK",
+            "details": {
+                "type": "pass",
+                "pass_key": "OK"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_cryptopol_krb5|krb5 governed by crypto policies.",
+            "component": "prodsec.rules.hardening_cryptopol_krb5.report",
+            "type": "pass",
+            "key": "krb5 governed by crypto policies.",
+            "details": {
+                "type": "pass",
+                "pass_key": "krb5 governed by crypto policies."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3666211"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_cryptopol_libssh|libssh governed by crypto policies.",
+            "component": "prodsec.rules.hardening_cryptopol_libssh.report",
+            "type": "pass",
+            "key": "libssh governed by crypto policies.",
+            "details": {
+                "type": "pass",
+                "pass_key": "libssh governed by crypto policies."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3666211"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_11477_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_11477_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-11477": "Kernel is not vulnerable.",
+                    "CVE-2019-11478": "Kernel is not vulnerable.",
+                    "CVE-2019-11479": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": [""],
+                "bugzilla": ["https://bugzilla.redhat.com/1719123"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_1000251_kernel_blueborne|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_1000251_kernel_blueborne.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-1000251": "Vulnerable kernel not running"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/blueborne"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1489716"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_13077_wpa_supplicant|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_13077_wpa_supplicant.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-13077": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/kracks"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1491692"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_13272_kernel_ptrace|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_13272_kernel_ptrace.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-13272": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/4292201"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1730895"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_5461_nss|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_5461_nss.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-5461": "Vulnerable package(s) not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1440080"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_1000366_glibc|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_1000366_glibc.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-1000364": "Vulnerable kernel and glibc not running",
+                    "CVE-2017-1000366": "Vulnerable kernel and glibc not running"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/stackguard"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1461333"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_1000368_sudo|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_1000368_sudo.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-1000368": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/3059071"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459152"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_7494_samba|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_7494_samba.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-7494": "The system is not vulnerable, SELinux mitigates the issue"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/3034621"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1450347"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2015_3456|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2015_3456.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2015-3456": "Vulnerable package not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/1444903"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1218611"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_25661_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_25661_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-25661": "Kernel is not vulnerable.",
+                    "CVE-2020-25662": "Kernel is not vulnerable.",
+                    "CVE-2020-24490": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/BleedingTooth"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1891483", "https://bugzilla.redhat.com/show_bug.cgi?id=1891484", "https://bugzilla.redhat.com/show_bug.cgi?id=1888449"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_19788_polkit|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_19788_polkit.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-19788": "Vulnerable package is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/25404"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1655925"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_25681_7_dnsmasq|Vulnerable package not installed.",
+            "component": "prodsec.rules.CVE_2020_25681_7_dnsmasq.report",
+            "type": "pass",
+            "key": "Vulnerable package not installed.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Vulnerable package not installed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-001"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1881875", "https://bugzilla.redhat.com/show_bug.cgi?id=1882014", "https://bugzilla.redhat.com/show_bug.cgi?id=1882018", "https://bugzilla.redhat.com/show_bug.cgi?id=1889686", "https://bugzilla.redhat.com/show_bug.cgi?id=1889688", "https://bugzilla.redhat.com/show_bug.cgi?id=1890125", "https://bugzilla.redhat.com/show_bug.cgi?id=1891568"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_1112_glusterfs|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_1112_glusterfs.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-1112": "Vulnerable glusterfs-server-3.8.4-54.7 is not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3422521"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570891"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_12351_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_12351_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-12351": "Kernel is not vulnerable.",
+                    "CVE-2020-12352": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/5493631"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1886521"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2015_7547_glibc|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2015_7547_glibc.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2015-7547": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/2168451"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1293532"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_2315_24_git|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_2315_24_git.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-2315": "Vulnerable package not installed",
+                    "CVE-2016-2324": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/2201201"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1317981"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_2776_bind|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_2776_bind.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-2776": "Vulnerable package is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1378380"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_3714_imagemagick|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_3714_imagemagick.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-3714": "Vulnerable package is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/ImageTragick"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1332492"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_1000250_bluez|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_1000250_bluez.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-1000250": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1489446"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_12207_cpu_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_12207_cpu_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-12207": "Cannot detect this vulnerability in VM guest."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/ifu-page-mce"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1646768"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_14835_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_14835_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-14835": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/kernel-vhost"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1750727"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_11048_php|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_11048_php.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-11048": "HTTPD or NGINX web server is not installed or active"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_smbloris_samba|Vulnerable package not installed",
+            "component": "prodsec.rules.CVE_2017_smbloris_samba.report",
+            "type": "pass",
+            "key": "Vulnerable package not installed",
+            "details": {
+                "type": "pass",
+                "pass_key": "Vulnerable package not installed"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/smbloris"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1478016"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVEs_samba_badlock|All CVEs passed.",
+            "component": "prodsec.rules.CVEs_samba_badlock.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-2118": "The vulnerable samba version is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/badlock", "https://access.redhat.com/articles/2243351"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1317990"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "bash_injection|All CVEs passed.",
+            "component": "prodsec.rules.bash_injection.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2014-6271": "Vulnerable package not installed",
+                    "CVE-2014-7169": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/1200223", "https://access.redhat.com/articles/1213683"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1141597", "https://bugzilla.redhat.com/show_bug.cgi?id=1146319"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_11135_cpu_taa|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_11135_cpu_taa.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-11135": "System is not vulnerable or is mitigated."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/tsx-asynchronousabort"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1753062"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "rpm_packages_checksum|rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn\"t report MD5 mismatches.",
+            "component": "prodsec.rules.rpm_packages_checksum.report",
+            "type": "pass",
+            "key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn\"t report MD5 mismatches.",
+            "details": {
+                "type": "pass",
+                "pass_key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn\"t report MD5 mismatches."
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2015_5600|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2015_5600.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2015-5600": "sshd settings not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1245969"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2015_7181_2_3_nss_nspr|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2015_7181_2_3_nss_nspr.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2015-7181": "Vulnerable package is not installed.",
+                    "CVE-2015-7182": "Vulnerable package is not installed.",
+                    "CVE-2015-7183": "Vulnerable package is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/2043623"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1269345", "https://bugzilla.redhat.com/show_bug.cgi?id=1269351", "https://bugzilla.redhat.com/show_bug.cgi?id=1269353"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_1002105_kubernetes|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_1002105_kubernetes.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-1002105": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/3716411"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1648138"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2015_7501_commons_collections|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2015_7501_commons_collections.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2015-7501": "Vulnerable package is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2045023"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1279330"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2021_3156_sudo|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2021_3156_sudo.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2021-3156": "The sudo package is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-002"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1917684"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_cryptopol_ssh_client|openssh-clients governed by crypto policies.",
+            "component": "prodsec.rules.hardening_cryptopol_ssh_client.report",
+            "type": "pass",
+            "key": "openssh-clients governed by crypto policies.",
+            "details": {
+                "type": "pass",
+                "pass_key": "openssh-clients governed by crypto policies."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3666211"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_cryptopol_sshd|sshd governed by crypto policies.",
+            "component": "prodsec.rules.hardening_cryptopol_sshd.report",
+            "type": "pass",
+            "key": "sshd governed by crypto policies.",
+            "details": {
+                "type": "pass",
+                "pass_key": "sshd governed by crypto policies."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3666211"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_14491_dnsmasq|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_14491_dnsmasq.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-14491": "Vulnerable package not installed"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/3199382"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1495409"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_8897_kernel_popss|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_8897_kernel_popss.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-8897": "Vulnerable kernel version is not running",
+                    "CVE-2018-1087": "Vulnerable kernel version is not running"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/pop_ss"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567074"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_5715_cpu_virt|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_5715_cpu_virt.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-5715": "The system is not exploitable because the relevant installed packages are not vulnerable and because the current combination and configuration of the CPU and kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/speculativeexecution"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519780"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_5753_4_cpu_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_5753_4_cpu_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-5753": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+                    "CVE-2017-5715": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+                    "CVE-2017-5754": "The current combination and configuration of the CPU and kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/speculativeexecution"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519778", "https://bugzilla.redhat.com/show_bug.cgi?id=1519781"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2021_30465_runc|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2021_30465_runc.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2021-30465": "Vulnerable package not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-004"],
+                "bugzilla": ["https://bugzilla.redhat.com/CVE-2021-30465"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_3620_cpu_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_3620_cpu_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-3620": "Vulnerability file indicates system not vulnerable.",
+                    "CVE-2018-3646": "Vulnerability file indicates system not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/L1TF"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1585005"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_12321_linux_firmware|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_12321_linux_firmware.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-12321": "linux-firmware is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/CVE-2020-12321"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_14634_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_14634_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-14634": "System with less than 16GB RAM cannot be exploited"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/mutagen-astronomy"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1624498"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_1111_dhcp|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_1111_dhcp.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-1111": "Vulnerable config not detected"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/3442151"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567974"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_14372_grub|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_14372_grub.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-14372": "The vulnerability is not applicable - system doesn\"t have Secure Boot enabled."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-003"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1873150"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVEs_Top10_2015_flash_plugin|All CVEs passed.",
+            "component": "prodsec.rules.CVEs_Top10_2015_flash_plugin.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2015-0359": "Firefox is not installed.",
+                    "CVE-2015-5119": "Firefox is not installed.",
+                    "CVE-2015-3113": "Firefox is not installed.",
+                    "CVE-2015-5122": "Firefox is not installed.",
+                    "CVE-2015-0311": "Firefox is not installed.",
+                    "CVE-2015-3090": "Firefox is not installed.",
+                    "CVE-2015-0336": "Firefox is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1188329", "https://bugzilla.redhat.com/show_bug.cgi?id=1211869", "https://bugzilla.redhat.com/show_bug.cgi?id=1240832", "https://bugzilla.redhat.com/show_bug.cgi?id=1235036", "https://bugzilla.redhat.com/show_bug.cgi?id=1242216", "https://bugzilla.redhat.com/show_bug.cgi?id=1185296", "https://bugzilla.redhat.com/show_bug.cgi?id=1221037", "https://bugzilla.redhat.com/show_bug.cgi?id=1201636"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2017_8779_rpc|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2017_8779_rpc.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2017-8779": "The system is not vulnerable, mitigation is applied"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3025811", "https://access.redhat.com/solutions/3053461"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1448124"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVEs_Top10_2016_flash_plugin|All CVEs passed.",
+            "component": "prodsec.rules.CVEs_Top10_2016_flash_plugin.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-1019": "Firefox is not installed.",
+                    "CVE-2016-4117": "Firefox is not installed.",
+                    "CVE-2015-8651": "Firefox is not installed.",
+                    "CVE-2016-1010": "Firefox is not installed.",
+                    "CVE-2015-8446": "Firefox is not installed.",
+                    "CVE-2015-7645": "Firefox is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1324353", "https://bugzilla.redhat.com/show_bug.cgi?id=1335058", "https://bugzilla.redhat.com/show_bug.cgi?id=1397987", "https://bugzilla.redhat.com/show_bug.cgi?id=1316809", "https://bugzilla.redhat.com/show_bug.cgi?id=1289771", "https://bugzilla.redhat.com/show_bug.cgi?id=1271966"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_10713_grub|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_10713_grub.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-10713": "Vulnerable package versions not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/grub2bootloader"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1825243"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_1125_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_1125_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-1125": "Vulnerability file indicates system not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/4329821"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1724389"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "heartbleed|All CVEs passed.",
+            "component": "prodsec.rules.heartbleed.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2014-0160": "The vulnerable openssl version is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/781793"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1084875"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_0800_openssl_drown|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_0800_openssl_drown.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-0800": "Vulnerable package is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/2176731"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1310593"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_tls_nginx|Nginx service is not installed.",
+            "component": "prodsec.rules.hardening_tls_nginx.report",
+            "type": "pass",
+            "key": "Nginx service is not installed.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Nginx service is not installed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2018_1000115_memcached|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2018_1000115_memcached.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2018-1000115": "memcached not accessible from external UDP connections"
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3369081"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1551182"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_unencrypted_ntalk|Ntalk not in use or not available to public addresses.",
+            "component": "prodsec.rules.hardening_unencrypted_ntalk.report",
+            "type": "pass",
+            "key": "Ntalk not in use or not available to public addresses.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Ntalk not in use or not available to public addresses."
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_ipv6_ip6tables|iptables is not installed.",
+            "component": "prodsec.rules.hardening_ipv6_ip6tables.report",
+            "type": "pass",
+            "key": "iptables is not installed.",
+            "details": {
+                "type": "pass",
+                "pass_key": "iptables is not installed."
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_tls_satellite|Httpd service is not installed.",
+            "component": "prodsec.rules.hardening_tls_satellite.report",
+            "type": "pass",
+            "key": "Httpd service is not installed.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Httpd service is not installed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/26833"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_unencrypted_rsh|Rsh not in use or not listening on public socket",
+            "component": "prodsec.rules.hardening_unencrypted_rsh.report",
+            "type": "pass",
+            "key": "Rsh not in use or not listening on public socket",
+            "details": {
+                "type": "pass",
+                "pass_key": "Rsh not in use or not listening on public socket"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_unsupported_xus|The system doesn\"t run EUS/AUS/TUS/E4S/ELS.",
+            "component": "prodsec.rules.hardening_unsupported_xus.report",
+            "type": "pass",
+            "key": "The system doesn\"t run EUS/AUS/TUS/E4S/ELS.",
+            "details": {
+                "type": "pass",
+                "pass_key": "The system doesn\"t run EUS/AUS/TUS/E4S/ELS."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/node/721513", "https://access.redhat.com/articles/4520991"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_tls_vsftpd|Vsftpd service is not installed.",
+            "component": "prodsec.rules.hardening_tls_vsftpd.report",
+            "type": "pass",
+            "key": "Vsftpd service is not installed.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Vsftpd service is not installed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/3436", "https://access.redhat.com/solutions/1320473"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_tls_httpd|Httpd service is not installed.",
+            "component": "prodsec.rules.hardening_tls_httpd.report",
+            "type": "pass",
+            "key": "Httpd service is not installed.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Httpd service is not installed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/26833"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_tls_dovecot|Dovecot service is not installed.",
+            "component": "prodsec.rules.hardening_tls_dovecot.report",
+            "type": "pass",
+            "key": "Dovecot service is not installed.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Dovecot service is not installed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/120383", "https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_unsupported_zstream|The system doesn\"t run non-EUS Z-Stream.",
+            "component": "prodsec.rules.hardening_unsupported_zstream.report",
+            "type": "pass",
+            "key": "The system doesn\"t run non-EUS Z-Stream.",
+            "details": {
+                "type": "pass",
+                "pass_key": "The system doesn\"t run non-EUS Z-Stream."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/238533", "https://access.redhat.com/solutions/2761031", "https://access.redhat.com/solutions/3433671"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_unencrypted_telnet|Telnet not in use or not listening on public socket.",
+            "component": "prodsec.rules.hardening_unencrypted_telnet.report",
+            "type": "pass",
+            "key": "Telnet not in use or not listening on public socket.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Telnet not in use or not listening on public socket."
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_unencrypted_avahi|Avahi not in use.",
+            "component": "prodsec.rules.hardening_unencrypted_avahi.report",
+            "type": "pass",
+            "key": "Avahi not in use.",
+            "details": {
+                "type": "pass",
+                "pass_key": "Avahi not in use."
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_9490_httpd|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_9490_httpd.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-9490": "Vulnerable httpd version is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/CVE-2020-9490"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2021_27365_kernel|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2021_27365_kernel.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2021-27365": "Kernel is not vulnerable."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/CVE-2021-27365"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "hardening_unencrypted_nis|NIS is not running or not available to public access.",
+            "component": "prodsec.rules.hardening_unencrypted_nis.report",
+            "type": "pass",
+            "key": "NIS is not running or not available to public access.",
+            "details": {
+                "type": "pass",
+                "pass_key": "NIS is not running or not available to public access."
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2019_5736_runc|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2019_5736_runc.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2019-5736": "Vulnerable package not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/runcescape"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1664908"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2016_9962_docker|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2016_9962_docker.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2016-9962": "Vulnerable package is not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/cve-2016-9962"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1409531"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_11100_haproxy|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_11100_haproxy.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-11100": "Vulnerable package not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/haproxy"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1819111"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "pass_id": "CVE_2020_14298_docker|All CVEs passed.",
+            "component": "prodsec.rules.CVE_2020_14298_docker.report",
+            "type": "pass",
+            "key": "All CVEs passed.",
+            "details": {
+                "cves": {
+                    "CVE-2020-14298": "Vulnerable package not installed.",
+                    "CVE-2020-14300": "Vulnerable package not installed.",
+                    "CVE-2016-8867": "Vulnerable package not installed."
+                },
+                "type": "pass",
+                "pass_key": "All CVEs passed."
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/security/vulnerabilities/runc-regression-docker-1.13.1-108"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1848239", "https://bugzilla.redhat.com/show_bug.cgi?id=1848829", "https://bugzilla.redhat.com/show_bug.cgi?id=1390163"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }],
+        "none": [{
+            "none_id": "network_vmxnet3_dropped_udp|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_vmxnet3_dropped_udp.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/67823"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_randomized_vm|NONE_KEY",
+            "component": "prodsec.rules.hardening_randomized_vm.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/44460"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_grub|NONE_KEY",
+            "component": "prodsec.rules.hardening_grub.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_fstab|NONE_KEY",
+            "component": "prodsec.rules.hardening_fstab.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/430253"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_max_uid|NONE_KEY",
+            "component": "prodsec.rules.hardening_max_uid.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/25404"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_browser_not_root|NONE_KEY",
+            "component": "prodsec.rules.hardening_browser_not_root.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/2094931"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_logging_audit_max_log|NONE_KEY",
+            "component": "prodsec.rules.hardening_logging_audit_max_log.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_bridge_multicast_fail|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_bridge_multicast_fail.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/361063", "https://access.redhat.com/solutions/784373"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1090670", "https://bugzilla.redhat.com/show_bug.cgi?id=1090749"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "net_source_routing_enabled|NONE_KEY",
+            "component": "prodsec.rules.net_source_routing_enabled.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/389853"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rport_delete_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.rport_delete_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1289833"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vfs_cache_pressure|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.vfs_cache_pressure.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/16995"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vm_min_free_kbytes_zero|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.vm_min_free_kbytes_zero.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1727288"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2676"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_selinux_policy|NONE_KEY",
+            "component": "prodsec.rules.hardening_selinux_policy.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "overcommit|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.overcommit.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/55207"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4129", "https://issues.redhat.com/browse/CEECBA-4984"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "tcp_tw_race|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.tcp_tw_race.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1390823"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_yum|NONE_KEY",
+            "component": "prodsec.rules.hardening_yum.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nfs_mount_unresponsive_with_disabled_tcp_timestamps|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.nfs_mount_unresponsive_with_disabled_tcp_timestamps.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2338"],
+                "kcs": ["https://access.redhat.com/solutions/3060231"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459978", "https://bugzilla.redhat.com/show_bug.cgi?id=1472128", "https://bugzilla.redhat.com/show_bug.cgi?id=1479043"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "numa_perf_regression|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.numa_perf_regression.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/802693"],
+                "jira": []
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "storage_mlx5_srp_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.storage_mlx5_srp_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2189191"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhevh_binfmt_misc_module_missing|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.rhevh_binfmt_misc_module_missing.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2427351", "https://access.redhat.com/solutions/2853231"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "selinux_disabled_kernel_panic|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.selinux_disabled_kernel_panic.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/4890471"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4701", "https://issues.redhat.com/browse/CEECBA-4962", "https://issues.redhat.com/browse/CEECBA-5240"],
+                "product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.1_release_notes/rhel-8_1_0_release#known-issue_security"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1778990"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "resolv_conf_over_three|NONE_KEY",
+            "component": "telemetry.rules.plugins.service.resolv_conf_over_three.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/6407"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cifs_share_lost|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.cifs_share_lost.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/713373"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cifs_find_writable_file_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.cifs_find_writable_file_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2735"],
+                "kcs": ["https://access.redhat.com/solutions/2110301"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1295008", "https://bugzilla.redhat.com/show_bug.cgi?id=1577086"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_gpg_pubkey|NONE_KEY",
+            "component": "prodsec.rules.hardening_gpg_pubkey.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cifs_null_pointer_dereference|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.cifs_null_pointer_dereference.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3485421"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1591092", "https://bugzilla.redhat.com/show_bug.cgi?id=1609159"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_hang_hp_bl460c_g7|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_hang_hp_bl460c_g7.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/257323"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "min_free_kbytes|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.min_free_kbytes.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-249", "https://projects.engineering.redhat.com/browse/CEECBA-3241"],
+                "kcs": ["https://access.redhat.com/solutions/336033"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hp_ilo4_nmi|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.hp_ilo4_nmi.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/707563"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_hpasr|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_hpasr.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/501543"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "alias_interface_invalid|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.alias_interface_invalid.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/21204"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nfs4_client_hang|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.nfs4_client_hang.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2162441", "https://access.redhat.com/solutions/2685641"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_panic_610_vxdmp_powerpath|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.kernel_panic_610_vxdmp_powerpath.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3676431"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_multiple_lo_ip_addr|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_multiple_lo_ip_addr.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2111561"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_nfs_stuck_syn_burst|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_nfs_stuck_syn_burst.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3018371"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "disabled_monitoring_bond|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bonding.disabled_monitoring_bond.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/172483"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-320"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ip_fragment_packet_drop|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.ip_fragment_packet_drop.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1498603"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "audit_backlog_limit_exceeded_panic|NONE_KEY",
+            "component": "telemetry.rules.plugins.service.audit_backlog_limit_exceeded_panic.retport",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/44602"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "incorrect_process_utimes|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.incorrect_process_utimes.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/185843"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "systemd_open_watchdog_nmi|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.systemd_open_watchdog_nmi.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1309033"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "qla2xxx_request_stuck|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.qla2xxx_request_stuck.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/189633"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_insufficient_tcp_page_allocation|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_insufficient_tcp_page_allocation.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2782"],
+                "kcs": ["https://access.redhat.com/solutions/4339681"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nfs4_delegation_infinite_loop|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.nfs4_delegation_infinite_loop.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+                "kcs": ["https://access.redhat.com/solutions/3164451"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459733"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "intel5500_interrupt_remapping_failure|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.intel5500_interrupt_remapping_failure.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-126"],
+                "kcs": ["https://access.redhat.com/solutions/110053"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=887006"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "tsc_rhel612_hung|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.tsc_rhel612_hung.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/60365"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "tsc_xeon_reboot_uptime|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.tsc_xeon_reboot_uptime.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/433883"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "bnx2fc_scan_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bnx2fc_scan_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/node/893403"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_slow_tcp_frto_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_slow_tcp_frto_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3658"],
+                "kcs": ["https://access.redhat.com/solutions/4978771"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1821522", "https://bugzilla.redhat.com/show_bug.cgi?id=1694860", "https://bugzilla.redhat.com/show_bug.cgi?id=1257096"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cciss_removed_on_rhel7|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.cciss_removed_on_rhel7.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/874443"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "dsa_filter_consumes_slab_objects|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.dsa_filter_consumes_slab_objects.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/4518431"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2968"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nic_speed_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.nic_speed_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/111173"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-667", "https://issues.redhat.com/browse/CEECBA-5474"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_nfs_world_access|NONE_KEY",
+            "component": "prodsec.rules.hardening_nfs_world_access.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3069421"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "find_busiest_group_div_0|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.find_busiest_group_div_0.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/58609"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "veritas_reservation_conflict|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.veritas_reservation_conflict.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+                "kcs": ["https://access.redhat.com/solutions/55885"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_panic_with_hardened_usercopy_due_to_splxmod|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.kernel_panic_with_hardened_usercopy_due_to_splxmod.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3441"],
+                "kcs": ["https://access.redhat.com/solutions/3959371"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ovirt_node_upgrade_failure_if_selinux_is_disabled|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.ovirt_node_upgrade_failure_if_selinux_is_disabled.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["http://access.redhat.com/solutions/3346371"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519784", "https://bugzilla.redhat.com/show_bug.cgi?id=1542833"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "glibc_nssdb_miss_i686|NONE_KEY",
+            "component": "telemetry.rules.plugins.tools.glibc_nssdb_miss_i686.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1807824"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3654"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cpu_max_frequency_not_maitained|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.cpu_max_frequency_not_maitained.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2836"],
+                "kcs": ["https://access.redhat.com/solutions/2895271"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nic_start_failed_at_boot|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.nic_start_failed_at_boot.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2523931"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "crash_in_memmap_init_zone|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.crash_in_memmap_init_zone.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3208581"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vm_swappiness_oom|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.vm_swappiness_oom.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1149413"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_stuck_uio_bug|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.kernel_stuck_uio_bug.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5487"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1952952"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "freeipmi_reboot|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.freeipmi_reboot.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/628963"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vpd_access_disabled|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.vpd_access_disabled.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3077141"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "docker_deferred_remove|NONE_KEY",
+            "component": "telemetry.rules.plugins.container.docker_deferred_remove.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+                "kcs": ["https://access.redhat.com/solutions/2517781"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kpatch_induces_panic|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.kpatch_induces_panic.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1845356"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3970"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "greenplum_database_hung|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.greenplum_database_hung.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2379961"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhev_host_certificates_expiration|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.rhev_host_certificates_expiration.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2985561"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ceph_kernel_client_append_write_bug|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.ceph_kernel_client_append_write_bug.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2329"],
+                "kcs": ["https://access.redhat.com/solutions/4254821"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1691227", "https://bugzilla.redhat.com/show_bug.cgi?id=1696594", "https://bugzilla.redhat.com/show_bug.cgi?id=1696595"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "docker_icc_false|NONE_KEY",
+            "component": "telemetry.rules.plugins.container.docker_icc_false.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2619411"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "crashkernel_with_3w_modules|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.crashkernel_with_3w_modules.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2335111"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_smbv1_client|NONE_KEY",
+            "component": "prodsec.rules.hardening_smbv1_client.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3164551"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vpd_rw_failed|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.vpd_rw_failed.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/39748", "https://access.redhat.com/solutions/633553"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "docker_journald_stop|NONE_KEY",
+            "component": "telemetry.rules.plugins.container.docker_journald_stop.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2533421"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rename_network_interface|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.rename_network_interface.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1446773"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_monitor_separate_disk|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_monitor_separate_disk.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3428961"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "wrong_cores_after_offline|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.wrong_cores_after_offline.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3468711"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "irqbalance_invalid_parsing|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.irqbalance_invalid_parsing.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2842141"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1393539"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nfs_with_fscache_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.nfs_with_fscache_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2431"],
+                "kcs": ["https://access.redhat.com/solutions/2328681", "https://access.redhat.com/solutions/2439131"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_neigh_thresh3|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_neigh_thresh3.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4984", "https://issues.redhat.com/browse/CEECBA-5276"],
+                "kcs": ["https://access.redhat.com/solutions/2789871"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "irqbalance_not_balancing|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.irqbalance_not_balancing.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/677073"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=987801"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "idm_ipa_server_openjdk_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.idm.idm_ipa_server_openjdk_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4575"],
+                "kcs": ["https://access.redhat.com/solutions/5527751", "https://access.redhat.com/solutions/5529501"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1892216"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_ntp_not_enabled|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_ntp_not_enabled.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "product_documentation": ["https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-ntp-synchronization"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "page_allocation_error|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.page_allocation_error.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/90883"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "irqbalance_not_running|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.irqbalance_not_running.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/41535"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3391"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nfs_mount_option_override_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.nfs_mount_option_override_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3547051"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1594707"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kvm_error_dev_shm_open_failed|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.kvm_error_dev_shm_open_failed.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2836251"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "leapp_upgrade_initramfs_missing|NONE_KEY",
+            "component": "telemetry.rules.plugins.leapp.leapp_upgrade_initramfs_missing.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5310"],
+                "kcs": ["https://access.redhat.com/solutions/6004981"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "isdn_hangup_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.isdn_hangup_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2374511"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "idm_ipv6_disabled|NONE_KEY",
+            "component": "telemetry.rules.plugins.idm.idm_ipv6_disabled.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3149991"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rebuild_initrd_failed|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.rebuild_initrd_failed.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/129173"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "megaraid_scsi_timeout_panic|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.megaraid_scsi_timeout_panic.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1787"],
+                "kcs": ["https://access.redhat.com/solutions/337313"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "pcc_cpufreq_driver_performance_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.pcc_cpufreq_driver_performance_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3804"],
+                "kcs": ["https://access.redhat.com/solutions/4379881", "https://access.redhat.com/solutions/3393161"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_panic_at_d_real|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.kernel_panic_at_d_real.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2537"],
+                "kcs": ["https://access.redhat.com/solutions/3248571"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "systemz_kdump_fail_with_devnode|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.systemz_kdump_fail_with_devnode.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/526113"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nproc_common_entries|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.nproc_common_entries.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/146233"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "python_symlink_misconfiguration|NONE_KEY",
+            "component": "telemetry.rules.plugins.service.python_symlink_misconfiguration.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-3797"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1779294"],
+                "product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#python_versions", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#configuring-the-unversioned-python_installing-and-using-python"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_max_tries|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_max_tries.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_protocol|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_protocol.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_device_unregister_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_device_unregister_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3177471"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_startups|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_startups.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_manager_dhcp_client_network_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_manager_dhcp_client_network_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4475"],
+                "kcs": ["https://access.redhat.com/solutions/5188461"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1843357"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "numa_node_mapping_255_cpus|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.numa_node_mapping_255_cpus.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1571393"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "pcc_cpufreq_fail_to_load|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.pcc_cpufreq_fail_to_load.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2546"],
+                "kcs": ["https://access.redhat.com/solutions/3421421"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_panic_radix_tree_lookup_s390x|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.kernel_panic_radix_tree_lookup_s390x.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2992"],
+                "kcs": ["https://access.redhat.com/solutions/4370121"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1725396"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhv_network_setup_failure_if_empty_line_in_ifcfg_files|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.rhv_network_setup_failure_if_empty_line_in_ifcfg_files.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2823131"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1406651"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nofile_set_to_unlimited_not_permitted|NONE_KEY",
+            "component": "telemetry.rules.plugins.shells.nofile_set_to_unlimited_not_permitted.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/33993"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4146"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vm_io_scheduler|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.vm_io_scheduler.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/5427"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_root_login|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_root_login.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ipa_client_short_hostname|NONE_KEY",
+            "component": "telemetry.rules.plugins.idm.ipa_client_short_hostname.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/200673"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3655"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_dhcp_connection_loss_nm_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_dhcp_connection_loss_nm_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2144"],
+                "kcs": ["https://access.redhat.com/solutions/1614093"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_manager_restart_fails_static_route|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_manager_restart_fails_static_route.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2215901"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1302532"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_hugepages_allocation_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.kernel_hugepages_allocation_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/869233"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4247", "https://issues.redhat.com/browse/CEECBA-4566"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "pacemaker_corosync_service_status|NONE_KEY",
+            "component": "telemetry.rules.plugins.clusterha.pacemaker_corosync_service_status.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/905823"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "qlcnic_old_firmware|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.qlcnic_old_firmware.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1287363"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ansible_deprecated_repo|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.ansible_deprecated_repo.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3359651"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567750"],
+                "jira": []
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "btrfs_unsupported_rhel8|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.btrfs_unsupported_rhel8.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/197643"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1533904"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "systemd_system_would_hang_in_shutting_down|NONE_KEY",
+            "component": "telemetry.rules.plugins.service.systemd_system_would_hang_in_shutting_down.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2277"],
+                "kcs": ["https://access.redhat.com/solutions/3181191"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1571098"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_dhcp_renew_lease_failed|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_dhcp_renew_lease_failed.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2236"],
+                "kcs": ["https://access.redhat.com/solutions/3672661"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_swap_on|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_swap_on.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3242331"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "race_in_kernel_sched_task_group|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.race_in_kernel_sched_task_group.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3085"],
+                "kcs": ["https://access.redhat.com/solutions/4621451"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "dnf_install_update_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.dnf_install_update_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3898"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1832869"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_sysctl_ipforward|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_sysctl_ipforward.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3586371"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhev_manager_certificates_expiration|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.rhev_manager_certificates_expiration.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2985561"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_hpsa|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_hpsa.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/44870"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=698268", "https://bugzilla.redhat.com/show_bug.cgi?id=715397"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_hpwdt_rhvh_sys_reset|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_hpwdt_rhvh_sys_reset.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3338821"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1491303"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3547"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhev_restart_libvirtd_after_stop_firewalld|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.rhev_restart_libvirtd_after_stop_firewalld.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2735671"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhev_vm_using_legacy_usb_devices|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.rhev_vm_using_legacy_usb_devices.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3054491"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1443078"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vmw_driver_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.vmware.vmw_driver_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/639963"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-715"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vmware_guest_clock_unstable|NONE_KEY",
+            "component": "telemetry.rules.plugins.vmware.vmware_guest_clock_unstable.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3215651"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rsyslog_memory_leak|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.rsyslog_memory_leak.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/4502651"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3499"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1714094"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_kptr_restrict_value|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_kptr_restrict_value.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2634"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1704572"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vmware_slabinfo_nmi_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.vmware.vmware_slabinfo_nmi_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/23884"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-907"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhevm_not_able_to_clone_vm_snapshot|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.rhevm_not_able_to_clone_vm_snapshot.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3205991"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1498478"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_large_lun_config|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_large_lun_config.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/node/1382643", "https://access.redhat.com/node/1480173"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1160104"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_bond1_not_working|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_bond1_not_working.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/262043"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_tuned_regression|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_tuned_regression.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2688", "https://issues.redhat.com/browse/CEECBA-5276"],
+                "kcs": ["https://access.redhat.com/solutions/4395931"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1739418"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_smbv1_server|NONE_KEY",
+            "component": "prodsec.rules.hardening_smbv1_server.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3164551"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_log_buf_len_consume|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_log_buf_len_consume.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1769173"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3041"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_firewall_zone_removed|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_firewall_zone_removed.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2770321"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "df_hangs_inconsistent_data_mtab|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.df_hangs_inconsistent_data_mtab.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3047"],
+                "kcs": ["https://access.redhat.com/solutions/3111191"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "leap_smear_chronyd_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.leap_smear_chronyd_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2759021"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "df_used_negative|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.df_used_negative.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/17835"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "leapsec_system_hard_hang|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.leapsec_system_hard_hang.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/154713", "https://access.redhat.com/solutions/154793"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "abort_command_issued|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.abort_command_issued.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/27624"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_dnssec_2|NONE_KEY",
+            "component": "prodsec.rules.hardening_dnssec_2.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/54644"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "aio_max_nr_limit_reached|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.aio_max_nr_limit_reached.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/479623"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_flash|NONE_KEY",
+            "component": "prodsec.rules.hardening_flash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3756821"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cifs_mount_ver_issue_in_fstab|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.cifs_mount_ver_issue_in_fstab.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3692491"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1650148", "https://bugzilla.redhat.com/show_bug.cgi?id=1657841"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "load_nfsmod_failed|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.load_nfsmod_failed.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+                "kcs": ["https://access.redhat.com/solutions/2314491"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ipmi_list_corruption_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.ipmi_list_corruption_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2690791"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vxfs_mount_fail_selinux_policy|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.vxfs_mount_fail_selinux_policy.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3168651", "https://access.redhat.com/solutions/3886991"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_need_bonding_parameter|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_need_bonding_parameter.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/69510"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_bnx2x_firmware_rt_kernel|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_bnx2x_firmware_rt_kernel.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2987451"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "mce_logs_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.mce_logs_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3160241"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_client_alive|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_client_alive.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hp_gen8_gen9_kvm_vm_not_start|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.hp_gen8_gen9_kvm_vm_not_start.retport",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3373571"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rx_crc_errors|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.rx_crc_errors.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/153413", "https://access.redhat.com/solutions/154543"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_config_perms|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_config_perms.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_iptables_services_fails|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_iptables_services_fails.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3138851"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_empty_passwords|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_empty_passwords.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "slow_performance_bgrt_mapping|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.slow_performance_bgrt_mapping.retport",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3802481"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1481667"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_tab_key|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_tab_key.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/195653"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhnsd_pid_world_write|NONE_KEY",
+            "component": "telemetry.rules.plugins.sysmgmt.registration.rhnsd_pid_world_write.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3220971"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1480306"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_ipv6_dev_route_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_ipv6_dev_route_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2716"],
+                "kcs": ["https://access.redhat.com/solutions/4209461"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_grace_time|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_grace_time.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rhsm_daemon_segfaults_in_libnl_so|NONE_KEY",
+            "component": "telemetry.rules.plugins.sysmgmt.registration.rhsm_daemon_segfaults_in_libnl_so.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/623753"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5040"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_hang_hp_gen9|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_hang_hp_gen9.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2797041"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "splunkd_memory_corruption|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.splunkd_memory_corruption.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1382833"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_vlan_mtu_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_vlan_mtu_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2162"],
+                "kcs": ["https://access.redhat.com/solutions/2888911"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1414186", "https://bugzilla.redhat.com/show_bug.cgi?id=1439166"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "subscription_cacert_expiration|NONE_KEY",
+            "component": "telemetry.rules.plugins.sysmgmt.registration.subscription_cacert_expiration.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3261461"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4841"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "stack_corrupted_using_xfs|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.stack_corrupted_using_xfs.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/54544"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_manager_custom_mtu_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_manager_custom_mtu_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2195741"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1303968"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "fs_resize2fs_bug|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.fs_resize2fs_bug.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-730", "https://issues.redhat.com/browse/CEECBA-4984"],
+                "kcs": ["https://access.redhat.com/solutions/173543"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_etcd_watch_retry|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_etcd_watch_retry.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4984", "https://issues.redhat.com/browse/CEECBA-5276"],
+                "kcs": ["https://access.redhat.com/solutions/3390441"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "missing_grub_symlink|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.missing_grub_symlink.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/770663"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "xinetd_per_source_limit|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.xinetd_per_source_limit.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-920", "https://issues.redhat.com/browse/CEECBA-4984"],
+                "kcs": ["https://access.redhat.com/solutions/1312084", "https://access.redhat.com/solutions/186273"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hpsa_task_blocked|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.hpsa_task_blocked.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1179703"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hugepage_over_reserved|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.hugepage_over_reserved.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2116991"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "be2net_generate_pause_frames|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.be2net_generate_pause_frames.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/349783"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "pcp_logger_network_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.pcp.pcp_logger_network_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4865"],
+                "kcs": ["https://access.redhat.com/solutions/5394191"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1875659", "https://bugzilla.redhat.com/show_bug.cgi?id=1854035"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hugepage_race_condition_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.hugepage_race_condition_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1992703"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nmi_switch_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.nmi_switch_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/265173"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "vlan_interface_gateway|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.vlan_interface_gateway.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2171881"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1309899"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "no_ept_panic_with_l1tf|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.no_ept_panic_with_l1tf.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3570921"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ifdown_alias_interface|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.ifdown_alias_interface.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2099351"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ibm_power_broken_topology|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.ibm_power_broken_topology.retport",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3669101"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1620038"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_initscripts_slave_config_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bonding.network_initscripts_slave_config_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2952041"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1428574"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ilo|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.ilo.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/744973"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_logging_auditd|NONE_KEY",
+            "component": "prodsec.rules.hardening_logging_auditd.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "gfs_mount_option_lock_nolock_is_unsupported|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.gfs_mount_option_lock_nolock_is_unsupported.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2255"],
+                "kcs": ["https://access.redhat.com/solutions/2592671"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "infiniband_rdma_data_corruption|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.infiniband_rdma_data_corruption.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4540"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1872424", "https://bugzilla.redhat.com/show_bug.cgi?id=1856158"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "start_lldpad_fcoe_cause_kernel_hang|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.start_lldpad_fcoe_cause_kernel_hang.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["http://access.redhat.com/solutions/3683051"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2470"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1353659", "https://bugzilla.redhat.com/show_bug.cgi?id=1656143", "https://bugzilla.redhat.com/show_bug.cgi?id=1656720"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_manager_arp_ip_address_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bonding.network_manager_arp_ip_address_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3952491"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1678796", "https://bugzilla.redhat.com/show_bug.cgi?id=1683092"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_logging_log_perms|NONE_KEY",
+            "component": "prodsec.rules.hardening_logging_log_perms.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "input_leds_soft_lockup|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.input_leds_soft_lockup.retport",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3521341"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "neutron_openvswitch_agent_fail_with_ryu_key_error|NONE_KEY",
+            "component": "telemetry.rules.plugins.osp.neutron_openvswitch_agent_fail_with_ryu_key_error.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3128111"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "udev_bug|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.udev_bug.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2592401"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "thp_defrag_performance|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.thp_defrag_performance.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/280443"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_manager_team_mac_address_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bonding.network_manager_team_mac_address_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2158"],
+                "kcs": ["https://access.redhat.com/solutions/3372231"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1569924"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "multipathd_start_failed|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.multipathd_start_failed.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1394763"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4984"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "tsc_reboot_uptime|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.tsc_reboot_uptime.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/68466"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "storage_fnic_storage_offline|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.storage_fnic_storage_offline.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2162451"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4212"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nic_rx_perf_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.nic_rx_perf_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/20278"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_nfs|NONE_KEY",
+            "component": "prodsec.rules.hardening_nfs.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "intel_purley_skylake_supportable|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.intel_purley_skylake_supportable.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3135591"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "idm_smbv1_windows_unsupport|NONE_KEY",
+            "component": "telemetry.rules.plugins.idm.idm_smbv1_windows_unsupport.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3164551"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_ipaddr_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_ipaddr_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2785051"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1394500"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "storage_iscsi_without_netdev|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.storage_iscsi_without_netdev.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3889"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "sanity_check_fstab|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.sanity_check_fstab.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/23769", "https://access.redhat.com/solutions/3109581"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3961"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_nfs_user_mountable|NONE_KEY",
+            "component": "prodsec.rules.hardening_nfs_user_mountable.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_panic_with_cbsensor_module|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.kernel_panic_with_cbsensor_module.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2929"],
+                "kcs": ["https://access.redhat.com/solutions/4544501"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_elasticsearch_pod_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_elasticsearch_pod_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/4395531"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3459", "https://issues.redhat.com/browse/CEECBA-5276"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_udev_sfc_interface_name_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_udev_sfc_interface_name_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3134621"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_selinux_virtualization|NONE_KEY",
+            "component": "prodsec.rules.hardening_selinux_virtualization.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/6144012"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "fips_enabled_rngd_cpu_consumption|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.fips_enabled_rngd_cpu_consumption.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4702"],
+                "kcs": ["https://access.redhat.com/solutions/5547981"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1884857"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "docker_daemon_huge_memory_usage|NONE_KEY",
+            "component": "telemetry.rules.plugins.container.docker_daemon_huge_memory_usage.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3223811"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_selinux_container|NONE_KEY",
+            "component": "prodsec.rules.hardening_selinux_container.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/6144032"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "setup_netdev_packetdrop_params|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.setup_netdev_packetdrop_params.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1241943"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "stale_tcp_tg3|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.stale_tcp_tg3.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/624593"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-142"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "neighbour_table_overflow|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.neighbour_table_overflow.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/23454", "https://access.redhat.com/solutions/3588721"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_blue_flame|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_blue_flame.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/437113"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_ifcfg_backup_conf_files|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_ifcfg_backup_conf_files.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3950", "https://projects.engineering.redhat.com/browse/CEECBA-4114"],
+                "kcs": ["https://access.redhat.com/solutions/68127"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_bna_driver_panic|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_bna_driver_panic.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2820921"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_team_slave_mac_address_diff|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bonding.network_team_slave_mac_address_diff.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3402"],
+                "kcs": ["https://access.redhat.com/solutions/4065221"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1689774"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "corosync_heartbeat_bonding|NONE_KEY",
+            "component": "telemetry.rules.plugins.clusterha.corosync_heartbeat_bonding.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3068841", "https://access.redhat.com/solutions/27604"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3346"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "xen_netfront_packet_loss|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.xen_netfront_packet_loss.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2387391"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3480"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1348581"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ceph_increase_min_free_kbytes|NONE_KEY",
+            "component": "telemetry.rules.plugins.ceph.ceph_increase_min_free_kbytes.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2244"],
+                "kcs": ["https://access.redhat.com/solutions/3031521"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1704326"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "snmp_memory_consumption_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.service.snmp_memory_consumption_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/4409691"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1751195"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4458"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_manager_vlan_uuid_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_manager_vlan_uuid_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3421371"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1553595"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "rpm_database_problems|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.rpm_database_problems.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/1330653"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_mlx5_core_melanox_firmware_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_mlx5_core_melanox_firmware_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2975"],
+                "kcs": ["https://access.redhat.com/solutions/3122991"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1463367", "https://bugzilla.redhat.com/show_bug.cgi?id=1497604"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "mssql_sulogin_root_shell|NONE_KEY",
+            "component": "telemetry.rules.plugins.microsoft.mssql_sulogin_root_shell.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2421"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "aws_cloud_init_incorrectly_handles_multiple_authkeys|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.aws_cloud_init_incorrectly_handles_multiple_authkeys.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3397", "https://issues.redhat.com/browse/CEECBA-4424"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1642008"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ocp_certificates_expiration|NONE_KEY",
+            "component": "telemetry.rules.plugins.shift.ocp_certificates_expiration.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3850", "https://issues.redhat.com/browse/CEECBA-5276"],
+                "product_documentation": ["https://docs.openshift.com/container-platform/3.11/install_config/redeploying_certificates.html"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "aws_cloud_init_overrides_local_network_config|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.aws_cloud_init_overrides_local_network_config.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3442"],
+                "kcs": ["https://access.redhat.com/solutions/4350351"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1653131", "https://bugzilla.redhat.com/show_bug.cgi?id=1691685"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "aws_cloud_init_support_for_imdsv2|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.aws_cloud_init_support_for_imdsv2.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3599", "https://projects.engineering.redhat.com/browse/CEECBA-4195", "https://issues.redhat.com/browse/CEECBA-4343"],
+                "kcs": ["https://access.redhat.com/solutions/4977371"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1803095", "https://bugzilla.redhat.com/show_bug.cgi?id=1803094", "https://bugzilla.redhat.com/show_bug.cgi?id=1827207", "https://bugzilla.redhat.com/show_bug.cgi?id=1866612", "https://bugzilla.redhat.com/show_bug.cgi?id=1869670"],
+                "product_documentation": ["https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "gnome_hangs_after_a_long_uptime|NONE_KEY",
+            "component": "telemetry.rules.plugins.desktop.gnome_hangs_after_a_long_uptime.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2925"],
+                "kcs": ["https://access.redhat.com/solutions/3556951"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "aws_vif_driver_mtu_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.aws_vif_driver_mtu_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3578"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1502554"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cloud_init_fails_to_configure_network_device|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.cloud_init_fails_to_configure_network_device.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2927"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1602784"],
+                "changelog": ["https://code.launchpad.net/~otubo/cloud-init/+git/cloud-init/+merge/353436"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cloud_init_local_service_delays_reboot|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.cloud_init_local_service_delays_reboot.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3736", "https://projects.engineering.redhat.com/browse/CEECBA-4119"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1625874"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "oracle_tuned_profiles_oracle|NONE_KEY",
+            "component": "telemetry.rules.plugins.oracle.oracle_tuned_profiles_oracle.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196298", "https://bugzilla.redhat.com/show_bug.cgi?id=1447323"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3753"],
+                "kcs": ["https://access.redhat.com/solutions/2867881"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_tcp_pkt_drp_alloc_fail|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_tcp_pkt_drp_alloc_fail.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3171", "https://projects.engineering.redhat.com/browse/CEECBA-3241"],
+                "kcs": ["https://access.redhat.com/solutions/4091971"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1696664", "https://bugzilla.redhat.com/show_bug.cgi?id=1704326"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_nfs_hostname_bnx2|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_nfs_hostname_bnx2.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/135843"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_bnx2x_link_down_driver_fw_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_bnx2x_link_down_driver_fw_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/68961", "https://access.redhat.com/solutions/388813"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "failure_to_load_datasource|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.failure_to_load_datasource.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2813", "https://projects.engineering.redhat.com/browse/CEECBA-3510"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1738607"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_on_azure|NONE_KEY",
+            "component": "telemetry.rules.plugins.microsoft.kdump_on_azure.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2179"],
+                "kcs": ["https://access.redhat.com/solutions/3091051"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_iwlwifi_driver_sysctl_conf_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_iwlwifi_driver_sysctl_conf_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3618"],
+                "kcs": ["https://access.redhat.com/solutions/4205041"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1718118"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "mail_files_left|NONE_KEY",
+            "component": "telemetry.rules.plugins.service.mail_files_left.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/258603"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_target_available_memory_size|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_target_available_memory_size.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4303", "https://issues.redhat.com/browse/CEECBA-4967", "https://issues.redhat.com/browse/CEECBA-5255"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1868698"],
+                "kcs": ["https://access.redhat.com/articles/5676371"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "performance_impact_on_hyperv_vm_using_hv_netvsc_interface|NONE_KEY",
+            "component": "telemetry.rules.plugins.microsoft.performance_impact_on_hyperv_vm_using_hv_netvsc_interface.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/4975221"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3866", "https://issues.redhat.com/browse/CEECBA-4984"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1821814", "https://bugzilla.redhat.com/show_bug.cgi?id=1838600"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "pkla_check_authorization_process_task_uninterruptible_or_defunct|NONE_KEY",
+            "component": "telemetry.rules.plugins.shells.pkla_check_authorization_process_task_uninterruptible_or_defunct.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3213721"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570907"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2539", "https://issues.redhat.com/browse/CEECBA-4382"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ixgbevf_networking_enhance|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.ixgbevf_networking_enhance.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2740491"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4120"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1274175"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "unable_to_reset_password_on_rhel8_azure|NONE_KEY",
+            "component": "telemetry.rules.plugins.microsoft.unable_to_reset_password_on_rhel8_azure.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": ["azure", "rhel8"],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2804"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1708040"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "support_for_next_gen_arm_instances|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.support_for_next_gen_arm_instances.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3765"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1770979"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_mlx5_infiniband_drv_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_mlx5_infiniband_drv_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4700", "https://issues.redhat.com/browse/CEECBA-5130"],
+                "kcs": ["https://access.redhat.com/solutions/5601811"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1880184", "https://bugzilla.redhat.com/show_bug.cgi?id=1789380"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "be2net_dropped_large_packets|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.be2net_dropped_large_packets.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/659453"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-524"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "nmi_dazed_and_confused|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.nmi_dazed_and_confused.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/35402", "https://access.redhat.com/solutions/26467"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "ethernet_amd_epyc_iommu_performance_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.ethernet_amd_epyc_iommu_performance_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2521"],
+                "kcs": ["https://access.redhat.com/solutions/3237861"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1508644", "https://bugzilla.redhat.com/show_bug.cgi?id=1531456"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hyperv_guest_set_mtu_failure|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.hyperv_guest_set_mtu_failure.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2705511"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "unsupported_journal_mode|NONE_KEY",
+            "component": "telemetry.rules.plugins.filesystem.unsupported_journal_mode.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4938"],
+                "kcs": ["https://access.redhat.com/solutions/358963", "https://access.redhat.com/solutions/424073"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hypervisor_bridge_bonding_mode|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bonding.hypervisor_bridge_bonding_mode.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1045"],
+                "kcs": ["https://access.redhat.com/solutions/67546"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_infiniband_ipoib_crash_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_infiniband_ipoib_crash_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3465401"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "oracle_cluster_avahi_daemon|NONE_KEY",
+            "component": "telemetry.rules.plugins.oracle.oracle_cluster_avahi_daemon.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/25463"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-144", "https://issues.redhat.com/browse/CEECBA-4633"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_intel_nic_hang|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_intel_nic_hang.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/119653"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4317"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "networking_lvs_slow_performance|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.networking_lvs_slow_performance.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/node/92973"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "oracle_db_ps_fail_no_buff_mem|NONE_KEY",
+            "component": "telemetry.rules.plugins.oracle.oracle_db_ps_fail_no_buff_mem.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2945981"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3989"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "aws_microcode_loaded|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.aws_microcode_loaded.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3170"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1716333"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "osp_certificates_expiration|NONE_KEY",
+            "component": "telemetry.rules.plugins.osp.osp_certificates_expiration.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2942211"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "neutron_osp11_ha_bug|NONE_KEY",
+            "component": "telemetry.rules.plugins.osp.neutron_osp11_ha_bug.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1461110", "https://bugzilla.redhat.com/show_bug.cgi?id=1461111", "https://bugzilla.redhat.com/show_bug.cgi?id=1461113"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_hv_netvsc_driver_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_driver_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2531"],
+                "kcs": ["https://access.redhat.com/solutions/3949321"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1661632", "https://bugzilla.redhat.com/show_bug.cgi?id=1679997"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "tg3_driver_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.tg3_driver_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1834"],
+                "kcs": ["https://access.redhat.com/solutions/69382"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_packet_drop_cisco_vic_enic_driver|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_packet_drop_cisco_vic_enic_driver.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/387813"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4542"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "be2net_mccq|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.be2net_mccq.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/node/35572", "https://access.redhat.com/solutions/60857"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "cannot_update_rhv_manager_due_to_ansible_version_conflict|NONE_KEY",
+            "component": "telemetry.rules.plugins.rhev.cannot_update_rhv_manager_due_to_ansible_version_conflict.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4639"],
+                "kcs": ["https://access.redhat.com/solutions/5480561"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1887268", "https://bugzilla.redhat.com/show_bug.cgi?id=1887142"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "qlcnic_driver_crash|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.qlcnic_driver_crash.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/916883"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "crashkernel_reservation_value|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.crashkernel_reservation_value.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3483431", "https://access.redhat.com/solutions/916043", "https://access.redhat.com/solutions/3698411", "https://access.redhat.com/solutions/1186753"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3863", "https://issues.redhat.com/browse/CEECBA-4381", "https://issues.redhat.com/browse/CEECBA-5671"],
+                "product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/supported-kdump-configurations-and-targets_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_i40e_firmware_offload_support|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_i40e_firmware_offload_support.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2943651"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "panic_be2net_driver|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.panic_be2net_driver.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/node/60123"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_matrox_vga_legacy_bios_mgag200_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_matrox_vga_legacy_bios_mgag200_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4903"],
+                "kcs": ["https://access.redhat.com/solutions/5770681", "https://access.redhat.com/solutions/4639181"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1913519"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "insights_client_core_collection|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.insights_client_core_collection.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5042"],
+                "kcs": ["https://access.redhat.com/articles/5699071"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_vlan_corrupt_traffic|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_vlan_corrupt_traffic.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2966631"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_hv_netvsc_drv_miss_tx_queue_wakeup|NONE_KEY",
+            "component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_drv_miss_tx_queue_wakeup.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2879", "https://issues.redhat.com/browse/CEECBA-4401"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1841900", "https://bugzilla.redhat.com/show_bug.cgi?id=1781322", "https://bugzilla.redhat.com/show_bug.cgi?id=1774687", "https://bugzilla.redhat.com/show_bug.cgi?id=1842485"],
+                "kcs": ["https://access.redhat.com/solutions/5189981"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "oracle_tuning|NONE_KEY",
+            "component": "telemetry.rules.plugins.oracle.oracle_tuning.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/39188"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-233", "https://projects.engineering.redhat.com/browse/CEECBA-3830"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_vmxnet3_discard_ipv6|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_vmxnet3_discard_ipv6.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2987791"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "high_latency_issue_with_hv_netvsc_driver|NONE_KEY",
+            "component": "telemetry.rules.plugins.microsoft.high_latency_issue_with_hv_netvsc_driver.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3604", "https://projects.engineering.redhat.com/browse/CEECBA-4010"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1805950", "https://bugzilla.redhat.com/show_bug.cgi?id=1848130"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_ifb_checksum_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_ifb_checksum_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3425461"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-3501"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "CVE_2021_38647_omi|NONE_KEY",
+            "component": "prodsec.rules.CVE_2021_38647_omi.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {},
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_bnx2x_ptp_kernel_panic_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_bnx2x_ptp_kernel_panic_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3007"],
+                "kcs": ["https://access.redhat.com/solutions/3192002"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1344743", "https://bugzilla.redhat.com/show_bug.cgi?id=1518669"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_vmxnet3_driver_panic|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_vmxnet3_driver_panic.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/2662661"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "systemd_non_persistent_ifname|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.systemd_non_persistent_ifname.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4357"],
+                "kcs": ["https://access.redhat.com/solutions/2435891", "https://access.redhat.com/solutions/283233"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1520983", "https://bugzilla.redhat.com/show_bug.cgi?id=1793974", "https://bugzilla.redhat.com/show_bug.cgi?id=1859926"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_third_party_drivers|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_third_party_drivers.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://issues.redhat.com/browse/CEECBA-4304"],
+                "product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/installing-and-configuring-kdump_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1879558"],
+                "kcs": ["https://access.redhat.com/articles/5679941"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_veth_corrupt_pkt_application|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_veth_corrupt_pkt_application.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2140"],
+                "kcs": ["https://access.redhat.com/solutions/2173981"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_vlan_offloading_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_vlan_offloading_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3658131"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1640645"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "oracle_storage_tuning|NONE_KEY",
+            "component": "telemetry.rules.plugins.oracle.oracle_storage_tuning.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/2607861"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3829"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_ixgbe_nic_intel_X550_performance_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_ixgbe_nic_intel_X550_performance_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3243"],
+                "kcs": ["https://access.redhat.com/solutions/4636801"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1781429"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "missing_boot_files|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.missing_boot_files.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/369233"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_cisco_VIC_irq_imbalance|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_cisco_VIC_irq_imbalance.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2167"],
+                "kcs": ["https://access.redhat.com/solutions/4126461"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "selinux_selinuxtype|NONE_KEY",
+            "component": "telemetry.rules.plugins.other.selinux_selinuxtype.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/232483", "https://access.redhat.com/solutions/6062341"],
+                "jira": ["https://issues.redhat.com/browse/CEECBA-5466", "https://projects.engineering.redhat.com/browse/CEECBA-641"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_qlogic_qede_nic_init_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_qlogic_qede_nic_init_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3720331"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kernel_crash_at_shpc_probe|NONE_KEY",
+            "component": "telemetry.rules.plugins.vmware.kernel_crash_at_shpc_probe.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2672", "https://issues.redhat.com/browse/CEECBA-5193"],
+                "kcs": ["https://access.redhat.com/solutions/3688401"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_nic_i40e_i40evf_driver_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_nic_i40e_i40evf_driver_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2937"],
+                "kcs": ["https://access.redhat.com/solutions/3753111"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1722774", "https://bugzilla.redhat.com/show_bug.cgi?id=1454890"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "oracle_java_se_access_not_available|NONE_KEY",
+            "component": "telemetry.rules.plugins.java.oracle_java_se_access_not_available.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/articles/3253281", "https://access.redhat.com/solutions/732883"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "check_debugshell|NONE_KEY",
+            "component": "telemetry.rules.plugins.service.check_debugshell.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2397"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "xen_pv_guest_boot_failure|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.xen_pv_guest_boot_failure.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3307791"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1531294"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3478", "https://projects.engineering.redhat.com/browse/CEECBA-4305"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "xen_pv_guest_panic_with_eagerfpu|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.xen_pv_guest_panic_with_eagerfpu.retport",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3551871"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "el7_to_el8_upgrade|NONE_KEY",
+            "component": "telemetry.rules.plugins.leapp.el7_to_el8_upgrade.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3199", "https://issues.redhat.com/browse/CEECBA-4533", "https://issues.redhat.com/browse/CEECBA-3792", "https://issues.redhat.com/browse/CEECBA-4677", "https://issues.redhat.com/browse/CEECBA-5079", "https://issues.redhat.com/browse/CEECBA-5294"],
+                "product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index"],
+                "kcs": ["https://access.redhat.com/solutions/4120411", "https://access.redhat.com/solutions/4824451", "https://access.redhat.com/solutions/5154031"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_vlan_i40e_driver_offloading_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_vlan_i40e_driver_offloading_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2797"],
+                "kcs": ["https://access.redhat.com/solutions/3662011"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1589450"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "kdump_iommu|NONE_KEY",
+            "component": "telemetry.rules.plugins.kdump.kdump_iommu.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/69019"],
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-457"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_intel_uhd_graphic_network_card_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.network_intel_uhd_graphic_network_card_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3013"],
+                "kcs": ["https://access.redhat.com/solutions/4154511"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1711234"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hpdsa_version_incompatible|NONE_KEY",
+            "component": "telemetry.rules.plugins.kernel.hpdsa_version_incompatible.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3337891"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "network_team_bond_slave_be2net_driver_issue|NONE_KEY",
+            "component": "telemetry.rules.plugins.networking.bonding.network_team_bond_slave_be2net_driver_issue.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2611"],
+                "kcs": ["https://access.redhat.com/solutions/2328621"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1337318", "https://bugzilla.redhat.com/show_bug.cgi?id=1382354"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "fc_hba_init_failure_during_boot|NONE_KEY",
+            "component": "telemetry.rules.plugins.storage.fc_hba_init_failure_during_boot.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3421081"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570785", "https://bugzilla.redhat.com/show_bug.cgi?id=1584377", "https://bugzilla.redhat.com/show_bug.cgi?id=1657981"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "aws_kdump_boot_stuck_specific_instance_type|NONE_KEY",
+            "component": "telemetry.rules.plugins.aws.aws_kdump_boot_stuck_specific_instance_type.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4054"],
+                "bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1844522"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_httpd_virtualhost|NONE_KEY",
+            "component": "prodsec.rules.hardening_httpd_virtualhost.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/3022811"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }, {
+            "none_id": "hardening_ssh_hmac_cipher|NONE_KEY",
+            "component": "prodsec.rules.hardening_ssh_hmac_cipher.report",
+            "type": "none",
+            "key": "NONE_KEY",
+            "details": {
+                "type": "none",
+                "none_key": "NONE_KEY"
+            },
+            "tags": [],
+            "links": {
+                "kcs": ["https://access.redhat.com/solutions/420283https://access.redhat.com/articles/3666211"]
+            },
+            "system_id": "5e71b703-4789-4564-8dff-590f57a14525"
+        }],
+        "analysis_metadata": {
+            "start": "2021-12-29T06:52:54.287508+00:00",
+            "finish": "2021-12-29T06:52:55.869243+00:00",
+            "execution_context": "insights.core.context.SerializedArchiveContext",
+            "plugin_sets": {
+                "insights-core": {
+                    "version": "insights-core-3.0.254-1",
+                    "commit": "placeholder"
+                },
+                "insights-plugins": {
+                    "version": "insights-plugins-2.0.200-1",
+                    "commit": "placeholder"
+                },
+                "insights-prodsec-rules": {
+                    "version": "insights-prodsec-rules-1.0.133-1",
+                    "commit": "placeholder"
+                }
+            }
+        }
+    }
+}

--- a/sample-files/insights-engine-result-undersized.json
+++ b/sample-files/insights-engine-result-undersized.json
@@ -1,0 +1,6450 @@
+{
+	"input": {
+		"platform_metadata": {
+			"account": "0000001",
+			"b64_identity": "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMSIsInR5cGUiOiAiVXNlciIsInVzZXIiOiB7InVzZXJuYW1lIjogInR1c2VyQHJlZGhhdC5jb20iLCJlbWFpbCI6ICJ0dXNlckByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6ICJ0ZXN0IiwibGFzdF9uYW1lIjogInVzZXIiLCJpc19hY3RpdmUiOiB0cnVlLCJpc19vcmdfYWRtaW4iOiBmYWxzZSwgImlzX2ludGVybmFsIjogdHJ1ZSwgImxvY2FsZSI6ICJlbl9VUyJ9LCJpbnRlcm5hbCI6IHsgIm9yZ19pZCI6ICIwMDAwMDEifX19Cg==",
+			"category": "collection",
+			"elapsed_time": 1640766910.6033278,
+			"extras": {},
+			"host": {},
+			"id": null,
+			"metadata": {
+				"reporter": "",
+				"stale_timestamp": "0001-01-01T00:00:00Z"
+			},
+			"payload_id": null,
+			"principal": "000001",
+			"request_id": "f77010e80955/miYkbDetAo-000008",
+			"satellite_managed": null,
+			"service": "advisor",
+			"size": 2600960,
+			"timestamp": "2021-12-29T08:35:08.492775002Z",
+			"url": "http://minio:9000/insights-upload-perma/f77010e80955/miYkbDetAo-000008?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211229%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211229T083508Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=7974a2afce5640213e29e1dd6900737dd94a6482fec0236da251223c712ee4bf",
+			"validation": null,
+			"test": null,
+			"is_ros": "true"
+		},
+		"metadata": {
+			"request_id": "f77010e80955/miYkbDetAo-000008"
+		},
+		"host": {
+			"bios_uuid": "ec2c79ab-02ff-d09b-31a9-583a902dd74b",
+			"satellite_id": null,
+			"subscription_manager_id": "4b1efbbe-a447-48d0-98c3-3594aae1d2c5",
+			"stale_warning_timestamp": "2022-01-06T13:35:11.545729+00:00",
+			"per_reporter_staleness": {
+				"puptoo": {
+					"last_check_in": "2021-12-29T08:35:11.655095+00:00",
+					"stale_timestamp": "2021-12-30T13:35:11.545729+00:00",
+					"check_in_succeeded": true
+				}
+			},
+			"fqdn": "ip-172-31-28-69.ec2.internal",
+			"system_profile": {
+				"os_release": "8.4",
+				"os_kernel_version": "4.18.0",
+				"satellite_managed": false
+			},
+			"ip_addresses": ["172.31.28.69"],
+			"created": "2021-12-17T18:55:36.339120+00:00",
+			"updated": "2021-12-29T08:35:11.655412+00:00",
+			"reporter": "puptoo",
+			"culled_timestamp": "2022-01-13T13:35:11.545729+00:00",
+			"id": "5879a2a2-a8a0-42b5-bcb2-de0e8a895dc8",
+			"rhel_machine_id": null,
+			"display_name": "ip-172-31-28-69.ec2.internal",
+			"stale_timestamp": "2021-12-30T13:35:11.545729+00:00",
+			"insights_id": "a319580a-2321-47c7-b061-886548bea067",
+			"account": "0000001",
+			"provider_type": null,
+			"tags": [],
+			"provider_id": null,
+			"ansible_host": null,
+			"mac_addresses": ["0a:94:1d:36:ff:21", "00:00:00:00:00:00"]
+		},
+		"type": "updated",
+		"timestamp": "2021-12-29T08:35:11.674044+00:00"
+	},
+	"results": {
+		"system": {
+			"metadata": {
+				"timezone_information": {
+					"utcoffset": 0,
+					"timezone": "UTC"
+				},
+				"bios_information": {
+					"bios_revision": "4.2",
+					"release_date": "08/24/2006",
+					"vendor": "Xen",
+					"version": "4.2.amazon"
+				},
+				"system_information": {
+					"product_name": "HVM domU",
+					"family": "Not Specified",
+					"manufacturer": "Xen",
+					"virtual_machine": true
+				},
+				"rhel_version": "8.4",
+				"cpu_utilization": "90",
+				"mem_utilization": "97",
+				"io_utilization": {
+					"xvda": "0.314"
+				},
+				"release": "Red Hat Enterprise Linux release 8.4 (Ootpa)"
+			},
+			"hostname": "ip-172-31-28-69.ec2.internal",
+			"remote_branch": -1,
+			"remote_leaf": -1,
+			"system_id": "a319580a-2321-47c7-b061-886548bea067",
+			"product": "rhel",
+			"type": "host"
+		},
+		"reports": [{
+			"rule_id": "insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+			"component": "telemetry.rules.plugins.other.insights_core_egg_not_up2date.report",
+			"type": "rule",
+			"key": "INSIGHTS_CORE_EGG_NOT_UP2DATE",
+			"details": {
+				"rhel": "8.4",
+				"cur": "3.0.251-1",
+				"rel": "3.0.255",
+				"type": "rule",
+				"error_key": "INSIGHTS_CORE_EGG_NOT_UP2DATE"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4587"],
+				"kcs": ["https://access.redhat.com/articles/3747741"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"rule_id": "CVE_2021_33909_kernel|CVE_2021_33909",
+			"component": "prodsec.rules.CVE_2021_33909_kernel.report",
+			"type": "rule",
+			"key": "CVE_2021_33909",
+			"details": {
+				"kernel_package_name": "kernel",
+				"running_kernel": "4.18.0-305.el8",
+				"cves": {
+					"CVE-2021-33909": false
+				},
+				"type": "rule",
+				"error_key": "CVE_2021_33909"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2021-33909"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"rule_id": "xen_kdump_supported|XEN_KDUMP_SUPPORTED_V1",
+			"component": "telemetry.rules.plugins.aws.xen_kdump_supported.report",
+			"type": "rule",
+			"key": "XEN_KDUMP_SUPPORTED_V1",
+			"details": {
+				"rhel_version": "8.4",
+				"type": "rule",
+				"error_key": "XEN_KDUMP_SUPPORTED_V1"
+			},
+			"tags": ["xen", "rhel8", "aws", "rhel7", "rhel6"],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2890881"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3484", "https://projects.engineering.redhat.com/browse/CEECBA-4123", "https://issues.redhat.com/browse/CEECBA-5304"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1859233", "https://bugzilla.redhat.com/show_bug.cgi?id=1954906"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"rule_id": "CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2",
+			"component": "prodsec.rules.CVE_2018_3639_cpu_kernel.report",
+			"type": "rule",
+			"key": "CVE_2018_3639_CPU_BAD_MICROCODE_2",
+			"details": {
+				"vuln_file_present": true,
+				"cmd_avail": true,
+				"running_kernel": "4.18.0-305.el8.x86_64",
+				"rt": false,
+				"cloud_provider": "Amazon Web Services",
+				"virtualization": "xen",
+				"cves": {
+					"CVE-2018-3639": false
+				},
+				"type": "rule",
+				"error_key": "CVE_2018_3639_CPU_BAD_MICROCODE_2"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/ssbd"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1566890"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"rule_id": "ntp_leapsmear|NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+			"component": "telemetry.rules.plugins.service.ntp_leapsmear.report",
+			"type": "rule",
+			"key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES",
+			"details": {
+				"smearing_servers": ["169.254.169.123"],
+				"smearing_patterns_len": 1,
+				"nonsmearing_servers": ["2.rhel.pool.ntp.org"],
+				"leap_directives": ["leapsectz right/UTC"],
+				"is_special_aws_ip_case": true,
+				"service": "chrony",
+				"type": "rule",
+				"error_key": "NTP_LEAPSMEAR_MIX_SERVER_SMEAR_AND_NOT_ONES"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/5132071"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3662", "https://projects.engineering.redhat.com/browse/CEECBA-4130"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"rule_id": "CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+			"component": "prodsec.rules.CVE_2018_12130_cpu_kernel.report",
+			"type": "rule",
+			"key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2",
+			"details": {
+				"rel": 8,
+				"vuln": ["Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown"],
+				"rt": false,
+				"cmd_any": false,
+				"cmdline_raw": "BOOT_IMAGE=(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64 root=UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585 ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+				"cmdline_dict": {
+					"BOOT_IMAGE": ["(hd0,gpt2)/boot/vmlinuz-4.18.0-305.el8.x86_64"],
+					"root": ["UUID=c9aa25ee-e65c-4818-9b2f-fa411d89f585"],
+					"ro": [true],
+					"console": ["ttyS0,115200n8", "tty0"],
+					"net.ifnames": ["0"],
+					"rd.blacklist": ["nouveau"],
+					"nvme_core.io_timeout": ["4294967295"],
+					"crashkernel": ["auto"]
+				},
+				"rh6nosmt": false,
+				"rh6nosmt1st": false,
+				"dmesg_wrapped": false,
+				"cloud_provider": "Amazon Web Services",
+				"virtualization": "xen",
+				"cves": {
+					"CVE-2018-12126": false,
+					"CVE-2018-12130": false,
+					"CVE-2018-12127": false,
+					"CVE-2019-11091": false
+				},
+				"type": "rule",
+				"error_key": "CVE_2018_12130_CPU_KERNEL_VULNERABLE_2"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/mds"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1646784"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"rule_id": "product_eol_check|AE_EOL_ERROR",
+			"component": "telemetry.rules.plugins.other.product_eol_check.report_ae",
+			"type": "rule",
+			"key": "AE_EOL_ERROR",
+			"details": {
+				"product": [{
+					"name": "Ansible Engine",
+					"version": "2.8",
+					"phase": "End of Life",
+					"eol": "2021-01-21",
+					"days": 343,
+					"policy": "https://access.redhat.com/support/policy/updates/ansible-engine"
+				}],
+				"brief": {
+					"Ansible Engine": "https://access.redhat.com/support/policy/updates/ansible-engine"
+				},
+				"type": "rule",
+				"error_key": "AE_EOL_ERROR"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-3825"],
+				"product_documentation": ["https://access.redhat.com/product-life-cycles", "https://access.redhat.com/support/policy/update_policies"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"rule_id": "ros_instance_evaluation|INSTANCE_UNDERSIZED",
+			"component": "telemetry.rules.plugins.ros.ros_instance_evaluation.report",
+			"type": "rule",
+			"key": "INSTANCE_UNDERSIZED",
+			"details": {
+				"rhel": "8.4",
+				"cloud_provider": "Amazon Web Services",
+				"instance_type": "t2.micro",
+				"region": "us-east-1",
+				"price": 0.0116,
+				"candidates": [
+					["t2.medium", 0.0464],
+					["t2.large", 0.0928],
+					["c1.medium", 0.13],
+					["m1.large", 0.175],
+					["t2.xlarge", 0.1856],
+					["m2.xlarge", 0.245],
+					["m1.xlarge", 0.35],
+					["t2.2xlarge", 0.3712],
+					["m2.2xlarge", 0.49],
+					["c1.xlarge", 0.52],
+					["g4dn.xlarge", 0.526],
+					["g4dn.2xlarge", 0.752],
+					["m2.4xlarge", 0.98],
+					["g4dn.4xlarge", 1.204],
+					["g4dn.8xlarge", 2.176],
+					["g4dn.12xlarge", 3.912],
+					["g4dn.16xlarge", 4.352]
+				],
+				"summary": ["CPU utilization is too high", "Memory utilization is too high"],
+				"type": "rule",
+				"error_key": "INSTANCE_UNDERSIZED"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5875"],
+				"kcs": []
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}],
+		"fingerprints": [],
+		"pass": [{
+			"pass_id": "CVE_2017_2636_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_2636_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-2636": "Vulnerable kernel not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/CVE-2017-2636"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1428319"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_0728_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_0728_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-0728": "The current running kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2132951"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1297475"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_7184_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_7184_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-7184": "The system is not running a vulnerable kernel."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1435153"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_5195_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_5195_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-5195": "The running kernel version is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2706661"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1384344"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_5696_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_5696_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-5696": "The running kernel version is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/challengeack"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1354708"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_passwd_perms|OK",
+			"component": "prodsec.rules.hardening_passwd_perms.report",
+			"type": "pass",
+			"key": "OK",
+			"details": {
+				"type": "pass",
+				"pass_key": "OK"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_1000405_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000405_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000405": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3253921"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1516514"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_14615_gpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_14615_gpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-14615": "Vulnerable module not loaded."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1789209"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_1000253_loadelf|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000253_loadelf.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000253": "Vulnerable kernel not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3189592"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1492212"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_0155_gpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_0155_gpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-0154": "Vulnerable module not loaded.",
+					"CVE-2019-0155": "Vulnerable module not loaded."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/i915-graphics"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1724393", "https://bugzilla.redhat.com/show_bug.cgi?id=1724398"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_6074_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_6074_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-6074": "Vulnerable kernel version is not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2934281"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1423071"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_12653_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12653_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12653": "Vulnerable kernel module not installed.",
+					"CVE-2020-12654": "Vulnerable kernel module not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1831868", "https://bugzilla.redhat.com/show_bug.cgi?id=1832530"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_12657_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12657_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12657": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2020-12657"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_tls_key_perms|OK",
+			"component": "prodsec.rules.hardening_tls_key_perms.report",
+			"type": "pass",
+			"key": "OK",
+			"details": {
+				"type": "pass",
+				"pass_key": "OK"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_cryptopol_krb5|krb5 governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_krb5.report",
+			"type": "pass",
+			"key": "krb5 governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "krb5 governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_cryptopol_libssh|libssh governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_libssh.report",
+			"type": "pass",
+			"key": "libssh governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "libssh governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_11477_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_11477_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-11477": "Kernel is not vulnerable.",
+					"CVE-2019-11478": "Kernel is not vulnerable.",
+					"CVE-2019-11479": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": [""],
+				"bugzilla": ["https://bugzilla.redhat.com/1719123"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_1000251_kernel_blueborne|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000251_kernel_blueborne.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000251": "Vulnerable kernel not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/blueborne"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1489716"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_13077_wpa_supplicant|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_13077_wpa_supplicant.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-13077": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/kracks"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1491692"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_13272_kernel_ptrace|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_13272_kernel_ptrace.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-13272": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/4292201"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1730895"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_5461_nss|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_5461_nss.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-5461": "Vulnerable package(s) not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1440080"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_1000366_glibc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000366_glibc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000364": "Vulnerable kernel and glibc not running",
+					"CVE-2017-1000366": "Vulnerable kernel and glibc not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/stackguard"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1461333"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_1000368_sudo|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000368_sudo.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000368": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3059071"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459152"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_7494_samba|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_7494_samba.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-7494": "The system is not vulnerable, SELinux mitigates the issue"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3034621"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1450347"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2015_3456|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_3456.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-3456": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/1444903"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1218611"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_25661_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_25661_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-25661": "Kernel is not vulnerable.",
+					"CVE-2020-25662": "Kernel is not vulnerable.",
+					"CVE-2020-24490": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/BleedingTooth"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1891483", "https://bugzilla.redhat.com/show_bug.cgi?id=1891484", "https://bugzilla.redhat.com/show_bug.cgi?id=1888449"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_19788_polkit|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_19788_polkit.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-19788": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/25404"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1655925"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_25681_7_dnsmasq|Vulnerable package not installed.",
+			"component": "prodsec.rules.CVE_2020_25681_7_dnsmasq.report",
+			"type": "pass",
+			"key": "Vulnerable package not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Vulnerable package not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-001"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1881875", "https://bugzilla.redhat.com/show_bug.cgi?id=1882014", "https://bugzilla.redhat.com/show_bug.cgi?id=1882018", "https://bugzilla.redhat.com/show_bug.cgi?id=1889686", "https://bugzilla.redhat.com/show_bug.cgi?id=1889688", "https://bugzilla.redhat.com/show_bug.cgi?id=1890125", "https://bugzilla.redhat.com/show_bug.cgi?id=1891568"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_1112_glusterfs|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1112_glusterfs.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1112": "Vulnerable glusterfs-server-3.8.4-54.7 is not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3422521"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570891"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_12351_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12351_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12351": "Kernel is not vulnerable.",
+					"CVE-2020-12352": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/5493631"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1886521"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2015_7547_glibc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_7547_glibc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-7547": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/2168451"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1293532"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_2315_24_git|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_2315_24_git.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-2315": "Vulnerable package not installed",
+					"CVE-2016-2324": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2201201"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1317981"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_2776_bind|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_2776_bind.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-2776": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1378380"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_3714_imagemagick|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_3714_imagemagick.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-3714": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/ImageTragick"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1332492"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_1000250_bluez|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_1000250_bluez.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-1000250": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1489446"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_12207_cpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_12207_cpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-12207": "Cannot detect this vulnerability in VM guest."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/ifu-page-mce"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1646768"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_14835_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_14835_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-14835": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/kernel-vhost"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1750727"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_11048_php|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_11048_php.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-11048": "HTTPD or NGINX web server is not installed or active"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_smbloris_samba|Vulnerable package not installed",
+			"component": "prodsec.rules.CVE_2017_smbloris_samba.report",
+			"type": "pass",
+			"key": "Vulnerable package not installed",
+			"details": {
+				"type": "pass",
+				"pass_key": "Vulnerable package not installed"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/smbloris"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1478016"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVEs_samba_badlock|All CVEs passed.",
+			"component": "prodsec.rules.CVEs_samba_badlock.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-2118": "The vulnerable samba version is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/badlock", "https://access.redhat.com/articles/2243351"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1317990"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "bash_injection|All CVEs passed.",
+			"component": "prodsec.rules.bash_injection.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2014-6271": "Vulnerable package not installed",
+					"CVE-2014-7169": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/1200223", "https://access.redhat.com/articles/1213683"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1141597", "https://bugzilla.redhat.com/show_bug.cgi?id=1146319"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_11135_cpu_taa|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_11135_cpu_taa.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-11135": "System is not vulnerable or is mitigated."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/tsx-asynchronousabort"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1753062"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "rpm_packages_checksum|rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches.",
+			"component": "prodsec.rules.rpm_packages_checksum.report",
+			"type": "pass",
+			"key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches.",
+			"details": {
+				"type": "pass",
+				"pass_key": "rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony doesn't report MD5 mismatches."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2015_5600|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_5600.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-5600": "sshd settings not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1245969"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2015_7181_2_3_nss_nspr|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_7181_2_3_nss_nspr.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-7181": "Vulnerable package is not installed.",
+					"CVE-2015-7182": "Vulnerable package is not installed.",
+					"CVE-2015-7183": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2043623"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1269345", "https://bugzilla.redhat.com/show_bug.cgi?id=1269351", "https://bugzilla.redhat.com/show_bug.cgi?id=1269353"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_1002105_kubernetes|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1002105_kubernetes.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1002105": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3716411"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1648138"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2015_7501_commons_collections|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2015_7501_commons_collections.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-7501": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2045023"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1279330"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2021_3156_sudo|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2021_3156_sudo.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2021-3156": "The sudo package is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-002"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1917684"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_cryptopol_ssh_client|openssh-clients governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_ssh_client.report",
+			"type": "pass",
+			"key": "openssh-clients governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "openssh-clients governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_cryptopol_sshd|sshd governed by crypto policies.",
+			"component": "prodsec.rules.hardening_cryptopol_sshd.report",
+			"type": "pass",
+			"key": "sshd governed by crypto policies.",
+			"details": {
+				"type": "pass",
+				"pass_key": "sshd governed by crypto policies."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_14491_dnsmasq|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_14491_dnsmasq.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-14491": "Vulnerable package not installed"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3199382"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1495409"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_8897_kernel_popss|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_8897_kernel_popss.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-8897": "Vulnerable kernel version is not running",
+					"CVE-2018-1087": "Vulnerable kernel version is not running"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/pop_ss"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567074"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_5715_cpu_virt|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_5715_cpu_virt.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-5715": "The system is not exploitable because the relevant installed packages are not vulnerable and because the current combination and configuration of the CPU and kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/speculativeexecution"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519780"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_5753_4_cpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_5753_4_cpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-5753": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+					"CVE-2017-5715": "The current combination and configuration of the CPU and kernel is not vulnerable.",
+					"CVE-2017-5754": "The current combination and configuration of the CPU and kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/speculativeexecution"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519778", "https://bugzilla.redhat.com/show_bug.cgi?id=1519781"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2021_30465_runc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2021_30465_runc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2021-30465": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-004"],
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2021-30465"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_3620_cpu_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_3620_cpu_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-3620": "Vulnerability file indicates system not vulnerable.",
+					"CVE-2018-3646": "Vulnerability file indicates system not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/L1TF"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1585005"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_12321_linux_firmware|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_12321_linux_firmware.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-12321": "linux-firmware is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2020-12321"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_14634_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_14634_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-14634": "System with less than 16GB RAM cannot be exploited"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/mutagen-astronomy"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1624498"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_1111_dhcp|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1111_dhcp.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1111": "Vulnerable config not detected"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/3442151"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567974"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_14372_grub|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_14372_grub.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-14372": "The vulnerability is not applicable - system doesn't have Secure Boot enabled."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/RHSB-2021-003"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1873150"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVEs_Top10_2015_flash_plugin|All CVEs passed.",
+			"component": "prodsec.rules.CVEs_Top10_2015_flash_plugin.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2015-0359": "Firefox is not installed.",
+					"CVE-2015-5119": "Firefox is not installed.",
+					"CVE-2015-3113": "Firefox is not installed.",
+					"CVE-2015-5122": "Firefox is not installed.",
+					"CVE-2015-0311": "Firefox is not installed.",
+					"CVE-2015-3090": "Firefox is not installed.",
+					"CVE-2015-0336": "Firefox is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1188329", "https://bugzilla.redhat.com/show_bug.cgi?id=1211869", "https://bugzilla.redhat.com/show_bug.cgi?id=1240832", "https://bugzilla.redhat.com/show_bug.cgi?id=1235036", "https://bugzilla.redhat.com/show_bug.cgi?id=1242216", "https://bugzilla.redhat.com/show_bug.cgi?id=1185296", "https://bugzilla.redhat.com/show_bug.cgi?id=1221037", "https://bugzilla.redhat.com/show_bug.cgi?id=1201636"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2017_8779_rpc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2017_8779_rpc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2017-8779": "The system is not vulnerable, mitigation is applied"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3025811", "https://access.redhat.com/solutions/3053461"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1448124"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVEs_Top10_2016_flash_plugin|All CVEs passed.",
+			"component": "prodsec.rules.CVEs_Top10_2016_flash_plugin.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-1019": "Firefox is not installed.",
+					"CVE-2016-4117": "Firefox is not installed.",
+					"CVE-2015-8651": "Firefox is not installed.",
+					"CVE-2016-1010": "Firefox is not installed.",
+					"CVE-2015-8446": "Firefox is not installed.",
+					"CVE-2015-7645": "Firefox is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1324353", "https://bugzilla.redhat.com/show_bug.cgi?id=1335058", "https://bugzilla.redhat.com/show_bug.cgi?id=1397987", "https://bugzilla.redhat.com/show_bug.cgi?id=1316809", "https://bugzilla.redhat.com/show_bug.cgi?id=1289771", "https://bugzilla.redhat.com/show_bug.cgi?id=1271966"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_10713_grub|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_10713_grub.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-10713": "Vulnerable package versions not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/grub2bootloader"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1825243"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_1125_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_1125_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-1125": "Vulnerability file indicates system not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/4329821"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1724389"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "heartbleed|All CVEs passed.",
+			"component": "prodsec.rules.heartbleed.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2014-0160": "The vulnerable openssl version is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/781793"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1084875"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_0800_openssl_drown|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_0800_openssl_drown.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-0800": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2176731"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1310593"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_tls_nginx|Nginx service is not installed.",
+			"component": "prodsec.rules.hardening_tls_nginx.report",
+			"type": "pass",
+			"key": "Nginx service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Nginx service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2018_1000115_memcached|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2018_1000115_memcached.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2018-1000115": "memcached not accessible from external UDP connections"
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3369081"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1551182"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_unencrypted_ntalk|Ntalk not in use or not available to public addresses.",
+			"component": "prodsec.rules.hardening_unencrypted_ntalk.report",
+			"type": "pass",
+			"key": "Ntalk not in use or not available to public addresses.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Ntalk not in use or not available to public addresses."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_ipv6_ip6tables|iptables is not installed.",
+			"component": "prodsec.rules.hardening_ipv6_ip6tables.report",
+			"type": "pass",
+			"key": "iptables is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "iptables is not installed."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_tls_satellite|Httpd service is not installed.",
+			"component": "prodsec.rules.hardening_tls_satellite.report",
+			"type": "pass",
+			"key": "Httpd service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Httpd service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/26833"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_unencrypted_rsh|Rsh not in use or not listening on public socket",
+			"component": "prodsec.rules.hardening_unencrypted_rsh.report",
+			"type": "pass",
+			"key": "Rsh not in use or not listening on public socket",
+			"details": {
+				"type": "pass",
+				"pass_key": "Rsh not in use or not listening on public socket"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_unsupported_xus|The system doesn't run EUS/AUS/TUS/E4S/ELS.",
+			"component": "prodsec.rules.hardening_unsupported_xus.report",
+			"type": "pass",
+			"key": "The system doesn't run EUS/AUS/TUS/E4S/ELS.",
+			"details": {
+				"type": "pass",
+				"pass_key": "The system doesn't run EUS/AUS/TUS/E4S/ELS."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/721513", "https://access.redhat.com/articles/4520991"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_tls_vsftpd|Vsftpd service is not installed.",
+			"component": "prodsec.rules.hardening_tls_vsftpd.report",
+			"type": "pass",
+			"key": "Vsftpd service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Vsftpd service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/3436", "https://access.redhat.com/solutions/1320473"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_tls_httpd|Httpd service is not installed.",
+			"component": "prodsec.rules.hardening_tls_httpd.report",
+			"type": "pass",
+			"key": "Httpd service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Httpd service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123", "https://access.redhat.com/solutions/26833"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_tls_dovecot|Dovecot service is not installed.",
+			"component": "prodsec.rules.hardening_tls_dovecot.report",
+			"type": "pass",
+			"key": "Dovecot service is not installed.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Dovecot service is not installed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/120383", "https://access.redhat.com/solutions/2157131", "https://access.redhat.com/articles/1232123"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_unsupported_zstream|The system runs supported non-EUS Z-Stream or can get latest updates via yum.",
+			"component": "prodsec.rules.hardening_unsupported_zstream.report",
+			"type": "pass",
+			"key": "The system runs supported non-EUS Z-Stream or can get latest updates via yum.",
+			"details": {
+				"type": "pass",
+				"pass_key": "The system runs supported non-EUS Z-Stream or can get latest updates via yum."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/238533", "https://access.redhat.com/solutions/2761031", "https://access.redhat.com/solutions/3433671"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_unencrypted_telnet|Telnet not in use or not listening on public socket.",
+			"component": "prodsec.rules.hardening_unencrypted_telnet.report",
+			"type": "pass",
+			"key": "Telnet not in use or not listening on public socket.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Telnet not in use or not listening on public socket."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_unencrypted_avahi|Avahi not in use.",
+			"component": "prodsec.rules.hardening_unencrypted_avahi.report",
+			"type": "pass",
+			"key": "Avahi not in use.",
+			"details": {
+				"type": "pass",
+				"pass_key": "Avahi not in use."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_9490_httpd|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_9490_httpd.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-9490": "Vulnerable httpd version is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2020-9490"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2021_27365_kernel|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2021_27365_kernel.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2021-27365": "Kernel is not vulnerable."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/CVE-2021-27365"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "hardening_unencrypted_nis|NIS is not running or not available to public access.",
+			"component": "prodsec.rules.hardening_unencrypted_nis.report",
+			"type": "pass",
+			"key": "NIS is not running or not available to public access.",
+			"details": {
+				"type": "pass",
+				"pass_key": "NIS is not running or not available to public access."
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2019_5736_runc|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2019_5736_runc.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2019-5736": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/runcescape"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1664908"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2016_9962_docker|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2016_9962_docker.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2016-9962": "Vulnerable package is not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/cve-2016-9962"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1409531"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_11100_haproxy|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_11100_haproxy.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-11100": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/haproxy"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1819111"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"pass_id": "CVE_2020_14298_docker|All CVEs passed.",
+			"component": "prodsec.rules.CVE_2020_14298_docker.report",
+			"type": "pass",
+			"key": "All CVEs passed.",
+			"details": {
+				"cves": {
+					"CVE-2020-14298": "Vulnerable package not installed.",
+					"CVE-2020-14300": "Vulnerable package not installed.",
+					"CVE-2016-8867": "Vulnerable package not installed."
+				},
+				"type": "pass",
+				"pass_key": "All CVEs passed."
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/security/vulnerabilities/runc-regression-docker-1.13.1-108"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1848239", "https://bugzilla.redhat.com/show_bug.cgi?id=1848829", "https://bugzilla.redhat.com/show_bug.cgi?id=1390163"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}],
+		"none": [{
+			"none_id": "network_vmxnet3_dropped_udp|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_dropped_udp.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/67823"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_randomized_vm|NONE_KEY",
+			"component": "prodsec.rules.hardening_randomized_vm.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/44460"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_grub|NONE_KEY",
+			"component": "prodsec.rules.hardening_grub.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_fstab|NONE_KEY",
+			"component": "prodsec.rules.hardening_fstab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/430253"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_max_uid|NONE_KEY",
+			"component": "prodsec.rules.hardening_max_uid.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/25404"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_browser_not_root|NONE_KEY",
+			"component": "prodsec.rules.hardening_browser_not_root.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2094931"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_logging_audit_max_log|NONE_KEY",
+			"component": "prodsec.rules.hardening_logging_audit_max_log.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_bridge_multicast_fail|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bridge_multicast_fail.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/361063", "https://access.redhat.com/solutions/784373"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1090670", "https://bugzilla.redhat.com/show_bug.cgi?id=1090749"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "net_source_routing_enabled|NONE_KEY",
+			"component": "prodsec.rules.net_source_routing_enabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/389853"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rport_delete_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.rport_delete_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1289833"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vfs_cache_pressure|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vfs_cache_pressure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/16995"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vm_min_free_kbytes_zero|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vm_min_free_kbytes_zero.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1727288"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2676"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_selinux_policy|NONE_KEY",
+			"component": "prodsec.rules.hardening_selinux_policy.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "tcp_tw_race|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.tcp_tw_race.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1390823"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_yum|NONE_KEY",
+			"component": "prodsec.rules.hardening_yum.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nfs_mount_unresponsive_with_disabled_tcp_timestamps|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.nfs_mount_unresponsive_with_disabled_tcp_timestamps.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2338"],
+				"kcs": ["https://access.redhat.com/solutions/3060231"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1459978", "https://bugzilla.redhat.com/show_bug.cgi?id=1472128", "https://bugzilla.redhat.com/show_bug.cgi?id=1479043"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "numa_perf_regression|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.numa_perf_regression.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/802693"],
+				"jira": []
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "storage_mlx5_srp_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.storage_mlx5_srp_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2189191"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "selinux_disabled_kernel_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.selinux_disabled_kernel_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4890471"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4701", "https://issues.redhat.com/browse/CEECBA-4962", "https://issues.redhat.com/browse/CEECBA-5240"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.1_release_notes/rhel-8_1_0_release#known-issue_security"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1778990"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "resolv_conf_over_three|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.resolv_conf_over_three.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/6407"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cifs_share_lost|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.cifs_share_lost.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/713373"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cifs_find_writable_file_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.cifs_find_writable_file_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2735"],
+				"kcs": ["https://access.redhat.com/solutions/2110301"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1295008", "https://bugzilla.redhat.com/show_bug.cgi?id=1577086"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_gpg_pubkey|NONE_KEY",
+			"component": "prodsec.rules.hardening_gpg_pubkey.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cifs_null_pointer_dereference|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.cifs_null_pointer_dereference.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3485421"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1591092", "https://bugzilla.redhat.com/show_bug.cgi?id=1609159"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_hang_hp_bl460c_g7|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hang_hp_bl460c_g7.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/257323"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "min_free_kbytes|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.min_free_kbytes.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-249", "https://projects.engineering.redhat.com/browse/CEECBA-3241"],
+				"kcs": ["https://access.redhat.com/solutions/336033"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hp_ilo4_nmi|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hp_ilo4_nmi.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/707563"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_hpasr|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hpasr.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/501543"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "alias_interface_invalid|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.alias_interface_invalid.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/21204"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nfs4_client_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nfs4_client_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2162441", "https://access.redhat.com/solutions/2685641"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_610_vxdmp_powerpath|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.kernel_panic_610_vxdmp_powerpath.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3676431"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_multiple_lo_ip_addr|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_multiple_lo_ip_addr.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2111561"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_nfs_stuck_syn_burst|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_nfs_stuck_syn_burst.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3018371"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "disabled_monitoring_bond|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.disabled_monitoring_bond.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/172483"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-320"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ip_fragment_packet_drop|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.ip_fragment_packet_drop.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1498603"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "audit_backlog_limit_exceeded_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.audit_backlog_limit_exceeded_panic.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/44602"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "incorrect_process_utimes|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.incorrect_process_utimes.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/185843"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "systemd_open_watchdog_nmi|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.systemd_open_watchdog_nmi.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1309033"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "qla2xxx_request_stuck|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.qla2xxx_request_stuck.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/189633"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "intel5500_interrupt_remapping_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.intel5500_interrupt_remapping_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-126"],
+				"kcs": ["https://access.redhat.com/solutions/110053"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=887006"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "tsc_rhel612_hung|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.tsc_rhel612_hung.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/60365"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "tsc_xeon_reboot_uptime|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.tsc_xeon_reboot_uptime.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/433883"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "bnx2fc_scan_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bnx2fc_scan_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/893403"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_slow_tcp_frto_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_slow_tcp_frto_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3658"],
+				"kcs": ["https://access.redhat.com/solutions/4978771"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1821522", "https://bugzilla.redhat.com/show_bug.cgi?id=1694860", "https://bugzilla.redhat.com/show_bug.cgi?id=1257096"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cciss_removed_on_rhel7|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.cciss_removed_on_rhel7.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/874443"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "dsa_filter_consumes_slab_objects|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.dsa_filter_consumes_slab_objects.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4518431"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2968"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nic_speed_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.nic_speed_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/111173"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-667", "https://issues.redhat.com/browse/CEECBA-5474"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_nfs_world_access|NONE_KEY",
+			"component": "prodsec.rules.hardening_nfs_world_access.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3069421"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "find_busiest_group_div_0|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.find_busiest_group_div_0.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/58609"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_with_hardened_usercopy_due_to_splxmod|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_with_hardened_usercopy_due_to_splxmod.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3441"],
+				"kcs": ["https://access.redhat.com/solutions/3959371"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ovirt_node_upgrade_failure_if_selinux_is_disabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.ovirt_node_upgrade_failure_if_selinux_is_disabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["http://access.redhat.com/solutions/3346371"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1519784", "https://bugzilla.redhat.com/show_bug.cgi?id=1542833"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "glibc_nssdb_miss_i686|NONE_KEY",
+			"component": "telemetry.rules.plugins.tools.glibc_nssdb_miss_i686.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1807824"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3654"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cpu_max_frequency_not_maitained|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.cpu_max_frequency_not_maitained.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2836"],
+				"kcs": ["https://access.redhat.com/solutions/2895271"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nic_start_failed_at_boot|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.nic_start_failed_at_boot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2523931"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "crash_in_memmap_init_zone|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.crash_in_memmap_init_zone.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3208581"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vm_swappiness_oom|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vm_swappiness_oom.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1149413"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_stuck_uio_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_stuck_uio_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5487"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1952952"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "freeipmi_reboot|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.freeipmi_reboot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/628963"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vpd_access_disabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vpd_access_disabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3077141"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "docker_deferred_remove|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_deferred_remove.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/2517781"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kpatch_induces_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kpatch_induces_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1845356"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3970"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "greenplum_database_hung|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.greenplum_database_hung.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2379961"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rhev_host_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhev_host_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2985561"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ceph_kernel_client_append_write_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.ceph_kernel_client_append_write_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2329"],
+				"kcs": ["https://access.redhat.com/solutions/4254821"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1691227", "https://bugzilla.redhat.com/show_bug.cgi?id=1696594", "https://bugzilla.redhat.com/show_bug.cgi?id=1696595"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "docker_icc_false|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_icc_false.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2619411"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "crashkernel_with_3w_modules|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.crashkernel_with_3w_modules.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2335111"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_smbv1_client|NONE_KEY",
+			"component": "prodsec.rules.hardening_smbv1_client.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3164551"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vpd_rw_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.vpd_rw_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/39748", "https://access.redhat.com/solutions/633553"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "docker_journald_stop|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_journald_stop.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2533421"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rename_network_interface|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.rename_network_interface.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1446773"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ocp_monitor_separate_disk|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_monitor_separate_disk.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3428961"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "wrong_cores_after_offline|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.wrong_cores_after_offline.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3468711"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "irqbalance_invalid_parsing|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.irqbalance_invalid_parsing.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2842141"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1393539"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nfs_with_fscache_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.nfs_with_fscache_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2431"],
+				"kcs": ["https://access.redhat.com/solutions/2328681", "https://access.redhat.com/solutions/2439131"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "irqbalance_not_balancing|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.irqbalance_not_balancing.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/677073"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=987801"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "idm_ipa_server_openjdk_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.idm_ipa_server_openjdk_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4575"],
+				"kcs": ["https://access.redhat.com/solutions/5527751", "https://access.redhat.com/solutions/5529501"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1892216"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ocp_ntp_not_enabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_ntp_not_enabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"product_documentation": ["https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-ntp-synchronization"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nfs_mount_option_override_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.nfs_mount_option_override_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3547051"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1594707"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "leapp_upgrade_initramfs_missing|NONE_KEY",
+			"component": "telemetry.rules.plugins.leapp.leapp_upgrade_initramfs_missing.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5310"],
+				"kcs": ["https://access.redhat.com/solutions/6004981"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "isdn_hangup_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.isdn_hangup_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2374511"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "idm_ipv6_disabled|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.idm_ipv6_disabled.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3149991"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rebuild_initrd_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.rebuild_initrd_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/129173"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "megaraid_scsi_timeout_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.megaraid_scsi_timeout_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1787"],
+				"kcs": ["https://access.redhat.com/solutions/337313"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "pcc_cpufreq_driver_performance_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.pcc_cpufreq_driver_performance_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3804"],
+				"kcs": ["https://access.redhat.com/solutions/4379881", "https://access.redhat.com/solutions/3393161"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_at_d_real|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_at_d_real.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2537"],
+				"kcs": ["https://access.redhat.com/solutions/3248571"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "systemz_kdump_fail_with_devnode|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.systemz_kdump_fail_with_devnode.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/526113"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nproc_common_entries|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nproc_common_entries.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/146233"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "python_symlink_misconfiguration|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.python_symlink_misconfiguration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-3797"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1779294"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#python_versions", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#configuring-the-unversioned-python_installing-and-using-python"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_max_tries|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_max_tries.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_protocol|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_protocol.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_device_unregister_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_device_unregister_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3177471"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_startups|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_startups.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_manager_dhcp_client_network_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_dhcp_client_network_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4475"],
+				"kcs": ["https://access.redhat.com/solutions/5188461"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1843357"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "numa_node_mapping_255_cpus|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.numa_node_mapping_255_cpus.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1571393"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "pcc_cpufreq_fail_to_load|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.pcc_cpufreq_fail_to_load.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2546"],
+				"kcs": ["https://access.redhat.com/solutions/3421421"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_radix_tree_lookup_s390x|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_radix_tree_lookup_s390x.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2992"],
+				"kcs": ["https://access.redhat.com/solutions/4370121"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1725396"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rhv_network_setup_failure_if_empty_line_in_ifcfg_files|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhv_network_setup_failure_if_empty_line_in_ifcfg_files.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2823131"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1406651"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nofile_set_to_unlimited_not_permitted|NONE_KEY",
+			"component": "telemetry.rules.plugins.shells.nofile_set_to_unlimited_not_permitted.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/33993"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4146"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vm_io_scheduler|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.vm_io_scheduler.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/5427"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_root_login|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_root_login.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ipa_client_short_hostname|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.ipa_client_short_hostname.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/200673"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3655"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_dhcp_connection_loss_nm_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_dhcp_connection_loss_nm_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2144"],
+				"kcs": ["https://access.redhat.com/solutions/1614093"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_manager_restart_fails_static_route|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_restart_fails_static_route.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2215901"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1302532"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_hugepages_allocation_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_hugepages_allocation_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/869233"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4247", "https://issues.redhat.com/browse/CEECBA-4566"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "pacemaker_corosync_service_status|NONE_KEY",
+			"component": "telemetry.rules.plugins.clusterha.pacemaker_corosync_service_status.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/905823"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "qlcnic_old_firmware|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.qlcnic_old_firmware.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1287363"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ansible_deprecated_repo|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.ansible_deprecated_repo.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3359651"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1567750"],
+				"jira": []
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "btrfs_unsupported_rhel8|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.btrfs_unsupported_rhel8.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/197643"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1533904"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "systemd_system_would_hang_in_shutting_down|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.systemd_system_would_hang_in_shutting_down.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2277"],
+				"kcs": ["https://access.redhat.com/solutions/3181191"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1571098"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ocp_swap_on|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_swap_on.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3242331"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "race_in_kernel_sched_task_group|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.race_in_kernel_sched_task_group.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3085"],
+				"kcs": ["https://access.redhat.com/solutions/4621451"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "dnf_install_update_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.dnf_install_update_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3898"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1832869"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ocp_sysctl_ipforward|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_sysctl_ipforward.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3586371"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rhev_manager_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhev_manager_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2985561"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_hpsa|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hpsa.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/44870"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=698268", "https://bugzilla.redhat.com/show_bug.cgi?id=715397"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_hpwdt_rhvh_sys_reset|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hpwdt_rhvh_sys_reset.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3338821"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1491303"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3547"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rhev_vm_using_legacy_usb_devices|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhev_vm_using_legacy_usb_devices.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3054491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1443078"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vmw_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.vmw_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/639963"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-715"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vmware_guest_clock_unstable|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.vmware_guest_clock_unstable.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3215651"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rsyslog_memory_leak|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.rsyslog_memory_leak.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4502651"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3499"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1714094"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_kptr_restrict_value|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_kptr_restrict_value.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2634"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1704572"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vmware_slabinfo_nmi_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.vmware_slabinfo_nmi_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/23884"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-907"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rhevm_not_able_to_clone_vm_snapshot|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.rhevm_not_able_to_clone_vm_snapshot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3205991"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1498478"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_large_lun_config|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_large_lun_config.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/1382643", "https://access.redhat.com/node/1480173"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1160104"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_bond1_not_working|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_bond1_not_working.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/262043"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ocp_tuned_regression|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_tuned_regression.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2688", "https://issues.redhat.com/browse/CEECBA-5276"],
+				"kcs": ["https://access.redhat.com/solutions/4395931"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1739418"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_smbv1_server|NONE_KEY",
+			"component": "prodsec.rules.hardening_smbv1_server.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3164551"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_log_buf_len_consume|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_log_buf_len_consume.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1769173"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3041"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_firewall_zone_removed|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_firewall_zone_removed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2770321"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "df_hangs_inconsistent_data_mtab|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.df_hangs_inconsistent_data_mtab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3047"],
+				"kcs": ["https://access.redhat.com/solutions/3111191"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_hpsa_driver_phy_disk_pointer_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_hpsa_driver_phy_disk_pointer_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3485"],
+				"kcs": ["https://access.redhat.com/solutions/2112491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1334773", "https://bugzilla.redhat.com/show_bug.cgi?id=1334396", "https://bugzilla.redhat.com/show_bug.cgi?id=1335411", "https://bugzilla.redhat.com/show_bug.cgi?id=1334260"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "leap_smear_chronyd_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.leap_smear_chronyd_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2759021"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "df_used_negative|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.df_used_negative.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/17835"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "leapsec_system_hard_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.leapsec_system_hard_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/154713", "https://access.redhat.com/solutions/154793"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_dnssec_2|NONE_KEY",
+			"component": "prodsec.rules.hardening_dnssec_2.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/54644"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "aio_max_nr_limit_reached|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.aio_max_nr_limit_reached.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/479623"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_flash|NONE_KEY",
+			"component": "prodsec.rules.hardening_flash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3756821"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cifs_mount_ver_issue_in_fstab|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.cifs_mount_ver_issue_in_fstab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3692491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1650148", "https://bugzilla.redhat.com/show_bug.cgi?id=1657841"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "load_nfsmod_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.load_nfsmod_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/2314491"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ipmi_list_corruption_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.ipmi_list_corruption_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2690791"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vxfs_mount_fail_selinux_policy|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.vxfs_mount_fail_selinux_policy.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3168651", "https://access.redhat.com/solutions/3886991"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_need_bonding_parameter|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_need_bonding_parameter.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/69510"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_bnx2x_firmware_rt_kernel|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bnx2x_firmware_rt_kernel.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2987451"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "mce_logs_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.mce_logs_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3160241"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_client_alive|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_client_alive.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hp_gen8_gen9_kvm_vm_not_start|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hp_gen8_gen9_kvm_vm_not_start.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3373571"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rx_crc_errors|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.rx_crc_errors.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/153413", "https://access.redhat.com/solutions/154543"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_config_perms|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_config_perms.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_iptables_services_fails|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_iptables_services_fails.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3138851"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_empty_passwords|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_empty_passwords.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "slow_performance_bgrt_mapping|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.slow_performance_bgrt_mapping.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3802481"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1481667"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_tab_key|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_tab_key.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/195653"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rhnsd_pid_world_write|NONE_KEY",
+			"component": "telemetry.rules.plugins.sysmgmt.registration.rhnsd_pid_world_write.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3220971"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1480306"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_ipv6_dev_route_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ipv6_dev_route_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2716"],
+				"kcs": ["https://access.redhat.com/solutions/4209461"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_grace_time|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_grace_time.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_hang_hp_gen9|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_hang_hp_gen9.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2797041"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "splunkd_memory_corruption|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.splunkd_memory_corruption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1382833"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vlan_mtu_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_mtu_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2162"],
+				"kcs": ["https://access.redhat.com/solutions/2888911"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1414186", "https://bugzilla.redhat.com/show_bug.cgi?id=1439166"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "subscription_cacert_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.sysmgmt.registration.subscription_cacert_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3261461"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4841"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "stack_corrupted_using_xfs|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.stack_corrupted_using_xfs.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/54544"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_manager_custom_mtu_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_custom_mtu_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2195741"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1303968"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "fs_resize2fs_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.fs_resize2fs_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-730", "https://issues.redhat.com/browse/CEECBA-4984"],
+				"kcs": ["https://access.redhat.com/solutions/173543"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "missing_grub_symlink|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.missing_grub_symlink.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/770663"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hpsa_task_blocked|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hpsa_task_blocked.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1179703"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hugepage_over_reserved|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hugepage_over_reserved.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2116991"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "be2net_generate_pause_frames|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.be2net_generate_pause_frames.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/349783"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "pcp_logger_network_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.pcp.pcp_logger_network_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4865"],
+				"kcs": ["https://access.redhat.com/solutions/5394191"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1875659", "https://bugzilla.redhat.com/show_bug.cgi?id=1854035"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hugepage_race_condition_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hugepage_race_condition_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1992703"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nmi_switch_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nmi_switch_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/265173"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "vlan_interface_gateway|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.vlan_interface_gateway.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2171881"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1309899"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "no_ept_panic_with_l1tf|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.no_ept_panic_with_l1tf.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3570921"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ifdown_alias_interface|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.ifdown_alias_interface.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2099351"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ibm_power_broken_topology|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.ibm_power_broken_topology.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3669101"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1620038"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_initscripts_slave_config_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_initscripts_slave_config_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2952041"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1428574"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ilo|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.ilo.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/744973"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_logging_auditd|NONE_KEY",
+			"component": "prodsec.rules.hardening_logging_auditd.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "gfs_mount_option_lock_nolock_is_unsupported|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.gfs_mount_option_lock_nolock_is_unsupported.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2255"],
+				"kcs": ["https://access.redhat.com/solutions/2592671"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "infiniband_rdma_data_corruption|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.infiniband_rdma_data_corruption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4540"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1872424", "https://bugzilla.redhat.com/show_bug.cgi?id=1856158"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "start_lldpad_fcoe_cause_kernel_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.start_lldpad_fcoe_cause_kernel_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["http://access.redhat.com/solutions/3683051"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2470"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1353659", "https://bugzilla.redhat.com/show_bug.cgi?id=1656143", "https://bugzilla.redhat.com/show_bug.cgi?id=1656720"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_manager_arp_ip_address_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_manager_arp_ip_address_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3952491"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1678796", "https://bugzilla.redhat.com/show_bug.cgi?id=1683092"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_logging_log_perms|NONE_KEY",
+			"component": "prodsec.rules.hardening_logging_log_perms.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "neutron_openvswitch_agent_fail_with_ryu_key_error|NONE_KEY",
+			"component": "telemetry.rules.plugins.osp.neutron_openvswitch_agent_fail_with_ryu_key_error.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3128111"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "udev_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.udev_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2592401"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "thp_defrag_performance|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.thp_defrag_performance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/280443"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_manager_team_mac_address_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_manager_team_mac_address_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2158"],
+				"kcs": ["https://access.redhat.com/solutions/3372231"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1569924"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "multipathd_start_failed|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.multipathd_start_failed.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1394763"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4984"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "tsc_reboot_uptime|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.tsc_reboot_uptime.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/68466"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "storage_fnic_storage_offline|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.storage_fnic_storage_offline.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2162451"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4212"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nic_rx_perf_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.nic_rx_perf_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/20278"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_nfs|NONE_KEY",
+			"component": "prodsec.rules.hardening_nfs.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "intel_purley_skylake_supportable|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.intel_purley_skylake_supportable.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3135591"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "idm_smbv1_windows_unsupport|NONE_KEY",
+			"component": "telemetry.rules.plugins.idm.idm_smbv1_windows_unsupport.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3164551"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196140"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_ipaddr_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ipaddr_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2785051"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1394500"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "storage_iscsi_without_netdev|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.storage_iscsi_without_netdev.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3889"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "sanity_check_fstab|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.sanity_check_fstab.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/23769", "https://access.redhat.com/solutions/3109581"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3961"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_nfs_user_mountable|NONE_KEY",
+			"component": "prodsec.rules.hardening_nfs_user_mountable.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_with_cbsensor_module|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_with_cbsensor_module.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2929"],
+				"kcs": ["https://access.redhat.com/solutions/4544501"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "only_one_cpu_after_l1ft_udpate|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.only_one_cpu_after_l1ft_udpate.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3596941"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2525"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1623255"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ocp_elasticsearch_pod_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_elasticsearch_pod_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4395531"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3459", "https://issues.redhat.com/browse/CEECBA-5276"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_udev_sfc_interface_name_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_udev_sfc_interface_name_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3134621"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_selinux_virtualization|NONE_KEY",
+			"component": "prodsec.rules.hardening_selinux_virtualization.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/6144012"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "fips_enabled_rngd_cpu_consumption|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.fips_enabled_rngd_cpu_consumption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4702"],
+				"kcs": ["https://access.redhat.com/solutions/5547981"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1884857"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "docker_daemon_huge_memory_usage|NONE_KEY",
+			"component": "telemetry.rules.plugins.container.docker_daemon_huge_memory_usage.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3223811"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_selinux_container|NONE_KEY",
+			"component": "prodsec.rules.hardening_selinux_container.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/6144032"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_rcu_threads_online_cpus|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_rcu_threads_online_cpus.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1404313"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1208895"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3169"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_sfc_nic_tx_timeout|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_sfc_nic_tx_timeout.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2190681"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4199"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "setup_netdev_packetdrop_params|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.setup_netdev_packetdrop_params.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1241943"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "neighbour_table_overflow|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.neighbour_table_overflow.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/23454", "https://access.redhat.com/solutions/3588721"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_blue_flame|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_blue_flame.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/437113"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_ifcfg_backup_conf_files|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ifcfg_backup_conf_files.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3950", "https://projects.engineering.redhat.com/browse/CEECBA-4114"],
+				"kcs": ["https://access.redhat.com/solutions/68127"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_bna_driver_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bna_driver_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2820921"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "corosync_heartbeat_bonding|NONE_KEY",
+			"component": "telemetry.rules.plugins.clusterha.corosync_heartbeat_bonding.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3068841", "https://access.redhat.com/solutions/27604"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3346"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "xen_netfront_packet_loss|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.xen_netfront_packet_loss.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2387391"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3480"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1348581"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ceph_increase_min_free_kbytes|NONE_KEY",
+			"component": "telemetry.rules.plugins.ceph.ceph_increase_min_free_kbytes.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2244"],
+				"kcs": ["https://access.redhat.com/solutions/3031521"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1704326"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_randome_usercopy|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_randome_usercopy.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4547651"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4254"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_manager_vlan_uuid_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_manager_vlan_uuid_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3421371"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1553595"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "rpm_database_problems|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.rpm_database_problems.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/1330653"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_vmware_guest_vmci_sock_transport|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_vmware_guest_vmci_sock_transport.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4757"],
+				"kcs": ["https://access.redhat.com/solutions/1582653"],
+				"bugzilla": ["https://bugzilla.redhat.com/1253971"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_mlx5_core_melanox_firmware_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_mlx5_core_melanox_firmware_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2975"],
+				"kcs": ["https://access.redhat.com/solutions/3122991"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1463367", "https://bugzilla.redhat.com/show_bug.cgi?id=1497604"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "mssql_sulogin_root_shell|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.mssql_sulogin_root_shell.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2421"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "aws_cloud_init_incorrectly_handles_multiple_authkeys|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_cloud_init_incorrectly_handles_multiple_authkeys.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3397", "https://issues.redhat.com/browse/CEECBA-4424"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1642008"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ocp_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.shift.ocp_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3850", "https://issues.redhat.com/browse/CEECBA-5276"],
+				"product_documentation": ["https://docs.openshift.com/container-platform/3.11/install_config/redeploying_certificates.html"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "aws_cloud_init_overrides_local_network_config|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_cloud_init_overrides_local_network_config.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3442"],
+				"kcs": ["https://access.redhat.com/solutions/4350351"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1653131", "https://bugzilla.redhat.com/show_bug.cgi?id=1691685"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_cgroup_slabmem_leak_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_cgroup_slabmem_leak_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3291481"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4606"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1507149", "https://bugzilla.redhat.com/show_bug.cgi?id=1752421"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "aws_cloud_init_support_for_imdsv2|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_cloud_init_support_for_imdsv2.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3599", "https://projects.engineering.redhat.com/browse/CEECBA-4195", "https://issues.redhat.com/browse/CEECBA-4343"],
+				"kcs": ["https://access.redhat.com/solutions/4977371"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1803095", "https://bugzilla.redhat.com/show_bug.cgi?id=1803094", "https://bugzilla.redhat.com/show_bug.cgi?id=1827207", "https://bugzilla.redhat.com/show_bug.cgi?id=1866612", "https://bugzilla.redhat.com/show_bug.cgi?id=1869670"],
+				"product_documentation": ["https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "intel_sb_edac_driver_kernel_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.intel_sb_edac_driver_kernel_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3209"],
+				"kcs": ["https://access.redhat.com/solutions/2722761"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1353808"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "aws_vif_driver_mtu_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_vif_driver_mtu_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3578"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1502554"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_i40e_data_corruption_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_i40e_data_corruption_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2678"],
+				"kcs": ["https://access.redhat.com/solutions/3572961"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1404060", "https://bugzilla.redhat.com/show_bug.cgi?id=1413101"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cloud_init_fails_to_configure_network_device|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.cloud_init_fails_to_configure_network_device.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2927"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1602784"],
+				"changelog": ["https://code.launchpad.net/~otubo/cloud-init/+git/cloud-init/+merge/353436"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_i40e_mdd_detection_pf_reset|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_i40e_mdd_detection_pf_reset.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/4385541"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4093"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cloud_init_local_service_delays_reboot|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.cloud_init_local_service_delays_reboot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3736", "https://projects.engineering.redhat.com/browse/CEECBA-4119"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1625874"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "oracle_tuned_profiles_oracle|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_tuned_profiles_oracle.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1196298", "https://bugzilla.redhat.com/show_bug.cgi?id=1447323"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3753"],
+				"kcs": ["https://access.redhat.com/solutions/2867881"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_tcp_pkt_drp_alloc_fail|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_tcp_pkt_drp_alloc_fail.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3171", "https://projects.engineering.redhat.com/browse/CEECBA-3241"],
+				"kcs": ["https://access.redhat.com/solutions/4091971"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1696664", "https://bugzilla.redhat.com/show_bug.cgi?id=1704326"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_nfs_hostname_bnx2|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_nfs_hostname_bnx2.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/135843"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_bnx2x_link_down_driver_fw_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bnx2x_link_down_driver_fw_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/68961", "https://access.redhat.com/solutions/388813"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "failure_to_load_datasource|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.failure_to_load_datasource.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2813", "https://projects.engineering.redhat.com/browse/CEECBA-3510"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1738607"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "performance_impact_due_to_disabled_pcid_feature|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.performance_impact_due_to_disabled_pcid_feature.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3987"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1691421", "https://bugzilla.redhat.com/show_bug.cgi?id=1697940"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "slowness_console_aspeed_grahics_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.slowness_console_aspeed_grahics_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3664"],
+				"kcs": ["https://access.redhat.com/solutions/4545311"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1780145", "https://bugzilla.redhat.com/show_bug.cgi?id=1780146", "https://bugzilla.redhat.com/show_bug.cgi?id=1780147", "https://bugzilla.redhat.com/show_bug.cgi?id=1739623"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_on_azure|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.kdump_on_azure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2179"],
+				"kcs": ["https://access.redhat.com/solutions/3091051"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_iwlwifi_driver_sysctl_conf_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_iwlwifi_driver_sysctl_conf_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3618"],
+				"kcs": ["https://access.redhat.com/solutions/4205041"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1718118"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "mail_files_left|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.mail_files_left.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/258603"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_target_available_memory_size|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_target_available_memory_size.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4303", "https://issues.redhat.com/browse/CEECBA-4967", "https://issues.redhat.com/browse/CEECBA-5255"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1868698"],
+				"kcs": ["https://access.redhat.com/articles/5676371"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "pkla_check_authorization_process_task_uninterruptible_or_defunct|NONE_KEY",
+			"component": "telemetry.rules.plugins.shells.pkla_check_authorization_process_task_uninterruptible_or_defunct.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3213721"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570907"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2539", "https://issues.redhat.com/browse/CEECBA-4382"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ixgbevf_networking_enhance|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.ixgbevf_networking_enhance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2740491"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4120"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1274175"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "unable_to_reset_password_on_rhel8_azure|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.unable_to_reset_password_on_rhel8_azure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": ["azure", "rhel8"],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2804"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1708040"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "support_for_next_gen_arm_instances|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.support_for_next_gen_arm_instances.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3765"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1770979"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_mlx5_infiniband_drv_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_mlx5_infiniband_drv_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4700", "https://issues.redhat.com/browse/CEECBA-5130"],
+				"kcs": ["https://access.redhat.com/solutions/5601811"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1880184", "https://bugzilla.redhat.com/show_bug.cgi?id=1789380"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "be2net_dropped_large_packets|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.be2net_dropped_large_packets.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/659453"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-524"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_qlcnic_interface_hang_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_qlcnic_interface_hang_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2354511"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3337"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1403143", "https://bugzilla.redhat.com/show_bug.cgi?id=1342659"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "nmi_dazed_and_confused|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.nmi_dazed_and_confused.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/35402", "https://access.redhat.com/solutions/26467"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "ethernet_amd_epyc_iommu_performance_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.ethernet_amd_epyc_iommu_performance_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2521"],
+				"kcs": ["https://access.redhat.com/solutions/3237861"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1508644", "https://bugzilla.redhat.com/show_bug.cgi?id=1531456"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hyperv_guest_set_mtu_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hyperv_guest_set_mtu_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2705511"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "unsupported_journal_mode|NONE_KEY",
+			"component": "telemetry.rules.plugins.filesystem.unsupported_journal_mode.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4938"],
+				"kcs": ["https://access.redhat.com/solutions/358963", "https://access.redhat.com/solutions/424073"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hypervisor_bridge_bonding_mode|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.hypervisor_bridge_bonding_mode.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1045"],
+				"kcs": ["https://access.redhat.com/solutions/67546"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_ovs_vxlan_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ovs_vxlan_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2938"],
+				"kcs": ["https://access.redhat.com/solutions/4280441"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_infiniband_ipoib_crash_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_infiniband_ipoib_crash_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3465401"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vmxnet3_interface_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_interface_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2837431"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "oracle_cluster_avahi_daemon|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_cluster_avahi_daemon.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/25463"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-144", "https://issues.redhat.com/browse/CEECBA-4633"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_intel_nic_hang|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_intel_nic_hang.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/119653"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4317"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "networking_lvs_slow_performance|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.networking_lvs_slow_performance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/92973"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "oracle_db_ps_fail_no_buff_mem|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_db_ps_fail_no_buff_mem.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2945981"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3989"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "aws_microcode_loaded|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_microcode_loaded.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3170"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1716333"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "osp_certificates_expiration|NONE_KEY",
+			"component": "telemetry.rules.plugins.osp.osp_certificates_expiration.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2942211"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "neutron_osp11_ha_bug|NONE_KEY",
+			"component": "telemetry.rules.plugins.osp.neutron_osp11_ha_bug.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1461110", "https://bugzilla.redhat.com/show_bug.cgi?id=1461111", "https://bugzilla.redhat.com/show_bug.cgi?id=1461113"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_hv_netvsc_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2531"],
+				"kcs": ["https://access.redhat.com/solutions/3949321"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1661632", "https://bugzilla.redhat.com/show_bug.cgi?id=1679997"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "tg3_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.tg3_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-1834"],
+				"kcs": ["https://access.redhat.com/solutions/69382"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_packet_drop_cisco_vic_enic_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_packet_drop_cisco_vic_enic_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/387813"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4542"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_hv_netvsc_driver_ring_buffer_signal_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_driver_ring_buffer_signal_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2689"],
+				"kcs": ["https://access.redhat.com/solutions/3489351"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1591976", "https://bugzilla.redhat.com/show_bug.cgi?id=1605089"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "be2net_mccq|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.be2net_mccq.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/35572", "https://access.redhat.com/solutions/60857"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "cannot_update_rhv_manager_due_to_ansible_version_conflict|NONE_KEY",
+			"component": "telemetry.rules.plugins.rhev.cannot_update_rhv_manager_due_to_ansible_version_conflict.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4639"],
+				"kcs": ["https://access.redhat.com/solutions/5480561"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1887268", "https://bugzilla.redhat.com/show_bug.cgi?id=1887142"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "qlcnic_driver_crash|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.qlcnic_driver_crash.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/916883"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_rt_kernel_panic_interrupt_context_preemption|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_rt_kernel_panic_interrupt_context_preemption.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2552"],
+				"kcs": ["https://access.redhat.com/solutions/3061081"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1402121", "https://bugzilla.redhat.com/show_bug.cgi?id=1402837", "https://bugzilla.redhat.com/show_bug.cgi?id=1401779"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "crashkernel_reservation_value|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.crashkernel_reservation_value.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3483431", "https://access.redhat.com/solutions/916043", "https://access.redhat.com/solutions/3698411", "https://access.redhat.com/solutions/1186753"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3863", "https://issues.redhat.com/browse/CEECBA-4381", "https://issues.redhat.com/browse/CEECBA-5671"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/supported-kdump-configurations-and-targets_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "panic_be2net_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.panic_be2net_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/node/60123"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_matrox_vga_legacy_bios_mgag200_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_matrox_vga_legacy_bios_mgag200_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4903"],
+				"kcs": ["https://access.redhat.com/solutions/5770681", "https://access.redhat.com/solutions/4639181"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1913519"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "insights_client_core_collection|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.insights_client_core_collection.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5042"],
+				"kcs": ["https://access.redhat.com/articles/5699071"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vlan_corrupt_traffic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_corrupt_traffic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2966631"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_hv_netvsc_drv_miss_tx_queue_wakeup|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.network_hv_netvsc_drv_miss_tx_queue_wakeup.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2879", "https://issues.redhat.com/browse/CEECBA-4401"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1841900", "https://bugzilla.redhat.com/show_bug.cgi?id=1781322", "https://bugzilla.redhat.com/show_bug.cgi?id=1774687", "https://bugzilla.redhat.com/show_bug.cgi?id=1842485"],
+				"kcs": ["https://access.redhat.com/solutions/5189981"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "oracle_tuning|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_tuning.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/39188"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-233", "https://projects.engineering.redhat.com/browse/CEECBA-3830"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vmxnet3_discard_ipv6|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_discard_ipv6.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2987791"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "high_latency_issue_with_hv_netvsc_driver|NONE_KEY",
+			"component": "telemetry.rules.plugins.microsoft.high_latency_issue_with_hv_netvsc_driver.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3604", "https://projects.engineering.redhat.com/browse/CEECBA-4010"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1805950", "https://bugzilla.redhat.com/show_bug.cgi?id=1848130"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "CVE_2021_38647_omi|NONE_KEY",
+			"component": "prodsec.rules.CVE_2021_38647_omi.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vxlan_panic_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vxlan_panic_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2777"],
+				"kcs": ["https://access.redhat.com/solutions/3734801"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_bnx2x_ptp_kernel_panic_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_bnx2x_ptp_kernel_panic_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3007"],
+				"kcs": ["https://access.redhat.com/solutions/3192002"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1344743", "https://bugzilla.redhat.com/show_bug.cgi?id=1518669"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vmxnet3_driver_panic|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vmxnet3_driver_panic.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2662661"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "systemd_non_persistent_ifname|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.systemd_non_persistent_ifname.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4357"],
+				"kcs": ["https://access.redhat.com/solutions/2435891", "https://access.redhat.com/solutions/283233"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1520983", "https://bugzilla.redhat.com/show_bug.cgi?id=1793974", "https://bugzilla.redhat.com/show_bug.cgi?id=1859926"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_third_party_drivers|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_third_party_drivers.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://issues.redhat.com/browse/CEECBA-4304"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-kdump-memory-requirements", "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/installing-and-configuring-kdump_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1879558"],
+				"kcs": ["https://access.redhat.com/articles/5679941"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_veth_corrupt_pkt_application|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_veth_corrupt_pkt_application.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2140"],
+				"kcs": ["https://access.redhat.com/solutions/2173981"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vlan_offloading_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_offloading_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3658131"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1640645"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_ixgbe_nic_reset|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ixgbe_nic_reset.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/2070703"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4062"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "oracle_storage_tuning|NONE_KEY",
+			"component": "telemetry.rules.plugins.oracle.oracle_storage_tuning.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/2607861"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3829"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_ixgbe_nic_intel_X550_performance_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ixgbe_nic_intel_X550_performance_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3243"],
+				"kcs": ["https://access.redhat.com/solutions/4636801"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1781429"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "missing_boot_files|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.missing_boot_files.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/369233"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_cisco_VIC_irq_imbalance|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_cisco_VIC_irq_imbalance.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2167"],
+				"kcs": ["https://access.redhat.com/solutions/4126461"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "selinux_selinuxtype|NONE_KEY",
+			"component": "telemetry.rules.plugins.other.selinux_selinuxtype.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/232483", "https://access.redhat.com/solutions/6062341"],
+				"jira": ["https://issues.redhat.com/browse/CEECBA-5466", "https://projects.engineering.redhat.com/browse/CEECBA-641"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_nvidia_nouveau_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_nvidia_nouveau_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3378"],
+				"kcs": ["https://access.redhat.com/solutions/2990791"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1449338"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_xen_pv_guest_fails|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_xen_pv_guest_fails.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3115"],
+				"kcs": ["https://access.redhat.com/solutions/3544391"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1487754"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_qlogic_qede_nic_init_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_qlogic_qede_nic_init_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3720331"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_crash_at_shpc_probe|NONE_KEY",
+			"component": "telemetry.rules.plugins.vmware.kernel_crash_at_shpc_probe.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2672", "https://issues.redhat.com/browse/CEECBA-5193"],
+				"kcs": ["https://access.redhat.com/solutions/3688401"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kernel_panic_uefi_boot_loader_nopti_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.kernel_panic_uefi_boot_loader_nopti_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3314"],
+				"kcs": ["https://access.redhat.com/solutions/4214721"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1540061", "https://bugzilla.redhat.com/show_bug.cgi?id=1565700"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_nic_i40e_i40evf_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_nic_i40e_i40evf_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2937"],
+				"kcs": ["https://access.redhat.com/solutions/3753111"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1722774", "https://bugzilla.redhat.com/show_bug.cgi?id=1454890"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "oracle_java_se_access_not_available|NONE_KEY",
+			"component": "telemetry.rules.plugins.java.oracle_java_se_access_not_available.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/articles/3253281", "https://access.redhat.com/solutions/732883"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_ibmvnic_driver_kernel_panic_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_ibmvnic_driver_kernel_panic_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3769"],
+				"kcs": ["https://access.redhat.com/solutions/5059441"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1783775", "https://bugzilla.redhat.com/show_bug.cgi?id=1828708"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "check_debugshell|NONE_KEY",
+			"component": "telemetry.rules.plugins.service.check_debugshell.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2397"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "xen_pv_guest_boot_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.xen_pv_guest_boot_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3307791"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1531294"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3478", "https://projects.engineering.redhat.com/browse/CEECBA-4305"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "xen_pv_guest_panic_with_eagerfpu|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.xen_pv_guest_panic_with_eagerfpu.retport",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3551871"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "el7_to_el8_upgrade|NONE_KEY",
+			"component": "telemetry.rules.plugins.leapp.el7_to_el8_upgrade.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3199", "https://issues.redhat.com/browse/CEECBA-4533", "https://issues.redhat.com/browse/CEECBA-3792", "https://issues.redhat.com/browse/CEECBA-4677", "https://issues.redhat.com/browse/CEECBA-5079", "https://issues.redhat.com/browse/CEECBA-5294"],
+				"product_documentation": ["https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index"],
+				"kcs": ["https://access.redhat.com/solutions/4120411", "https://access.redhat.com/solutions/4824451", "https://access.redhat.com/solutions/5154031"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_vlan_i40e_driver_offloading_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_vlan_i40e_driver_offloading_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2797"],
+				"kcs": ["https://access.redhat.com/solutions/3662011"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1589450"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_lpfc_be2net_nic_failure|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_lpfc_be2net_nic_failure.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2224"],
+				"kcs": ["https://access.redhat.com/solutions/3964901"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1657981", "https://bugzilla.redhat.com/show_bug.cgi?id=1683908"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "kdump_iommu|NONE_KEY",
+			"component": "telemetry.rules.plugins.kdump.kdump_iommu.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/69019"],
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-457"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_intel_uhd_graphic_network_card_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.network_intel_uhd_graphic_network_card_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-3013"],
+				"kcs": ["https://access.redhat.com/solutions/4154511"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1711234"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hpdsa_version_incompatible|NONE_KEY",
+			"component": "telemetry.rules.plugins.kernel.hpdsa_version_incompatible.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3337891"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "network_team_bond_slave_be2net_driver_issue|NONE_KEY",
+			"component": "telemetry.rules.plugins.networking.bonding.network_team_bond_slave_be2net_driver_issue.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-2611"],
+				"kcs": ["https://access.redhat.com/solutions/2328621"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1337318", "https://bugzilla.redhat.com/show_bug.cgi?id=1382354"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "fc_hba_init_failure_during_boot|NONE_KEY",
+			"component": "telemetry.rules.plugins.storage.fc_hba_init_failure_during_boot.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3421081"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1570785", "https://bugzilla.redhat.com/show_bug.cgi?id=1584377", "https://bugzilla.redhat.com/show_bug.cgi?id=1657981"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "aws_kdump_boot_stuck_specific_instance_type|NONE_KEY",
+			"component": "telemetry.rules.plugins.aws.aws_kdump_boot_stuck_specific_instance_type.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"jira": ["https://projects.engineering.redhat.com/browse/CEECBA-4054"],
+				"bugzilla": ["https://bugzilla.redhat.com/show_bug.cgi?id=1844522"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_httpd_virtualhost|NONE_KEY",
+			"component": "prodsec.rules.hardening_httpd_virtualhost.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/3022811"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}, {
+			"none_id": "hardening_ssh_hmac_cipher|NONE_KEY",
+			"component": "prodsec.rules.hardening_ssh_hmac_cipher.report",
+			"type": "none",
+			"key": "NONE_KEY",
+			"details": {
+				"type": "none",
+				"none_key": "NONE_KEY"
+			},
+			"tags": [],
+			"links": {
+				"kcs": ["https://access.redhat.com/solutions/420283https://access.redhat.com/articles/3666211"]
+			},
+			"system_id": "a319580a-2321-47c7-b061-886548bea067"
+		}],
+		"analysis_metadata": {
+			"start": "2021-12-29T08:35:11.840697+00:00",
+			"finish": "2021-12-29T08:35:15.987467+00:00",
+			"execution_context": "insights.core.context.SerializedArchiveContext",
+			"plugin_sets": {
+				"insights-core": {
+					"version": "insights-core-3.0.254-1",
+					"commit": "placeholder"
+				},
+				"insights-plugins": {
+					"version": "insights-plugins-2.0.200-1",
+					"commit": "placeholder"
+				},
+				"insights-prodsec-rules": {
+					"version": "insights-prodsec-rules-1.0.133-1",
+					"commit": "placeholder"
+				}
+			}
+		}
+	}
+}

--- a/tests/test_archive_processor.py
+++ b/tests/test_archive_processor.py
@@ -34,6 +34,7 @@ EXPECTED_PERFORMANCE_RECORD = {
     },
     'mem.physmem': 32617072.0,
     'mem.util.available': 27455175.254,
+    'region': 'ap-northeast-1',
     'total_cpus': 1,
     'type': 'metadata'
 }
@@ -43,7 +44,7 @@ def test_performance_profile_response():
     # test setup
     lscpu = mock.Mock()
     setattr(lscpu, 'info', {'CPUs': '1'})
-    aws_instance_id = {'instanceType': 't2.micro'}
+    aws_instance_id = {'instanceType': 't2.micro', 'region': 'ap-northeast-1'}
     sample_pmlog_summary = {
       'hinv': {'ncpu': {'val': 8.0, 'units': 'none'}},
       'mem': {

--- a/tests/test_insights_engine_result_consumer.py
+++ b/tests/test_insights_engine_result_consumer.py
@@ -120,3 +120,19 @@ def test_process_report_undersized(engine_result_message, engine_consumer, db_se
         assert data.state == SYSTEM_STATES['INSTANCE_UNDERSIZED']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
                performance_record
+
+
+def test_process_report_optimized(engine_result_message, engine_consumer, db_setup, performance_record):
+    engine_result_message = engine_result_message("insights-engine-result-undersized.json")
+    host = engine_result_message["input"]["host"]
+    ros_reports = []
+    system_metadata = engine_result_message["results"]["system"]["metadata"]
+    current_performance_record = copy.copy(performance_record)
+    engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
+    data = db_get_host(host['id'])
+    assert str(data.inventory_id) == host['id']
+    with app.app_context():
+        assert data.instance_type == current_performance_record['instance_type']
+        assert data.state == SYSTEM_STATES['OPTIMIZED']
+        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
+               performance_record

--- a/tests/test_insights_engine_result_consumer.py
+++ b/tests/test_insights_engine_result_consumer.py
@@ -128,7 +128,7 @@ def test_process_report_undersized(engine_result_message, engine_consumer, db_se
 
 
 def test_process_report_optimized(engine_result_message, engine_consumer, db_setup, performance_record):
-    engine_result_message = engine_result_message("insights-engine-result-under-pressure.json")
+    engine_result_message = engine_result_message("insights-engine-result-optimized.json")
     host = engine_result_message["input"]["host"]
     ros_reports = []
     system_metadata = engine_result_message["results"]["system"]["metadata"]

--- a/tests/test_insights_engine_result_consumer.py
+++ b/tests/test_insights_engine_result_consumer.py
@@ -1,32 +1,35 @@
 import pytest
 import json
-
+import copy
 from ros.lib.app import app
 from ros.lib.models import db, PerformanceProfile
 from ros.processor.insights_engine_result_consumer import InsightsEngineResultConsumer, SYSTEM_STATES
 from tests.helpers.db_helper import db_get_host
 
 
-PERFORMANCE_RECORD = {
-    "hinv.ncpu": 8.0, "total_cpus": 1, "mem.physmem": 32617072.0,
-    "instance_type": "t2.micro", "disk.dev.total": {"nvme0n1": {"val": 7.22, "units": "count / sec"}},
-    "mem.util.available": 27455175.254, "kernel.all.cpu.idle": 7.55,
-    "kernel.all.pressure.io.full.avg": {"1 minute": {"val": 0.006, "units": "none"},
-                                        "5 minute": {"val": 0.004, "units": "none"},
-                                        "10 second": {"val": 0.012, "units": "none"}},
-    "kernel.all.pressure.io.some.avg": {"1 minute": {"val": 0.006, "units": "none"},
-                                        "5 minute": {"val": 0.004, "units": "none"},
-                                        "10 second": {"val": 0.013, "units": "none"}},
-    "kernel.all.pressure.cpu.some.avg": {"1 minute": {"val": 0.575, "units": "none"},
-                                         "5 minute": {"val": 0.572, "units": "none"},
-                                         "10 second": {"val": 0.579, "units": "none"}},
-    "kernel.all.pressure.memory.full.avg": {"1 minute": {"val": 0.0, "units": "none"},
-                                            "5 minute": {"val": 0.0, "units": "none"},
-                                            "10 second": {"val": 0.0, "units": "none"}},
-    "kernel.all.pressure.memory.some.avg": {"1 minute": {"val": 0.0, "units": "none"},
-                                            "5 minute": {"val": 0.0, "units": "none"},
-                                            "10 second": {"val": 0.0, "units": "none"}}
-}
+@pytest.fixture(scope="function")
+def performance_record():
+    PERFORMANCE_RECORD = {
+        "hinv.ncpu": 8.0, "total_cpus": 1, "mem.physmem": 32617072.0,
+        "instance_type": "t2.micro", "disk.dev.total": {"nvme0n1": {"val": 7.22, "units": "count / sec"}},
+        "mem.util.available": 27455175.254, "kernel.all.cpu.idle": 7.55, 'region': 'ap-northeast-1',
+        "kernel.all.pressure.io.full.avg": {"1 minute": {"val": 0.006, "units": "none"},
+                                            "5 minute": {"val": 0.004, "units": "none"},
+                                            "10 second": {"val": 0.012, "units": "none"}},
+        "kernel.all.pressure.io.some.avg": {"1 minute": {"val": 0.006, "units": "none"},
+                                            "5 minute": {"val": 0.004, "units": "none"},
+                                            "10 second": {"val": 0.013, "units": "none"}},
+        "kernel.all.pressure.cpu.some.avg": {"1 minute": {"val": 0.575, "units": "none"},
+                                             "5 minute": {"val": 0.572, "units": "none"},
+                                             "10 second": {"val": 0.579, "units": "none"}},
+        "kernel.all.pressure.memory.full.avg": {"1 minute": {"val": 0.0, "units": "none"},
+                                                "5 minute": {"val": 0.0, "units": "none"},
+                                                "10 second": {"val": 0.0, "units": "none"}},
+        "kernel.all.pressure.memory.some.avg": {"1 minute": {"val": 0.0, "units": "none"},
+                                                "5 minute": {"val": 0.0, "units": "none"},
+                                                "10 second": {"val": 0.0, "units": "none"}}
+    }
+    return PERFORMANCE_RECORD
 
 
 @pytest.fixture(scope="session")
@@ -44,11 +47,11 @@ def engine_consumer():
     return InsightsEngineResultConsumer()
 
 
-def test_handle_msg(engine_result_message, engine_consumer, mocker):
+def test_handle_msg(engine_result_message, engine_consumer, mocker, performance_record):
     engine_result_message = engine_result_message("insights-engine-result-idle-old.json")
     mocker.patch(
         'ros.processor.insights_engine_result_consumer.get_performance_profile',
-        return_value=PERFORMANCE_RECORD,
+        return_value=performance_record,
         autospec=True
     )
     mocker.patch.object(engine_consumer, 'process_report', return_value=True, autospec=True)
@@ -56,30 +59,32 @@ def test_handle_msg(engine_result_message, engine_consumer, mocker):
     engine_consumer.process_report.assert_called_once()
 
 
-def test_process_report_idle(engine_result_message, engine_consumer, db_setup):
+def test_process_report_idle(engine_result_message, engine_consumer, db_setup, performance_record):
     engine_result_message = engine_result_message("insights-engine-result-idle-old.json")
     host = engine_result_message["input"]["host"]
     ros_reports = [engine_result_message["results"]["reports"][4]]
     system_metadata = engine_result_message["results"]["system"]["metadata"]
-    engine_consumer.process_report(host, ros_reports, system_metadata, PERFORMANCE_RECORD)
+    current_performance_record = copy.copy(performance_record)
+    engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     data = db_get_host(host['id'])
     assert str(data.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == PERFORMANCE_RECORD['instance_type']
+        assert data.instance_type == current_performance_record['instance_type']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
-               PERFORMANCE_RECORD
+               performance_record
 
 
-def test_process_report_under_pressure(engine_result_message, engine_consumer, db_setup):
+def test_process_report_under_pressure(engine_result_message, engine_consumer, db_setup, performance_record):
     engine_result_message = engine_result_message("insights-engine-result-under-pressure.json")
     host = engine_result_message["input"]["host"]
     ros_reports = [engine_result_message["results"]["reports"][7]]
     system_metadata = engine_result_message["results"]["system"]["metadata"]
-    engine_consumer.process_report(host, ros_reports, system_metadata, PERFORMANCE_RECORD)
+    current_performance_record = copy.copy(performance_record)
+    engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     data = db_get_host(host['id'])
     assert str(data.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == PERFORMANCE_RECORD['instance_type']
+        assert data.instance_type == current_performance_record['instance_type']
         assert data.state == SYSTEM_STATES['INSTANCE_OPTIMIZED_UNDER_PRESSURE']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
-               PERFORMANCE_RECORD
+               performance_record

--- a/tests/test_insights_engine_result_consumer.py
+++ b/tests/test_insights_engine_result_consumer.py
@@ -64,12 +64,13 @@ def test_process_report_idle(engine_result_message, engine_consumer, db_setup, p
     host = engine_result_message["input"]["host"]
     ros_reports = [engine_result_message["results"]["reports"][4]]
     system_metadata = engine_result_message["results"]["system"]["metadata"]
-    current_performance_record = copy.copy(performance_record)
+    _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     data = db_get_host(host['id'])
     assert str(data.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == current_performance_record['instance_type']
+        assert data.instance_type == _performance_record['instance_type']
+        assert data.region == _performance_record['region']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
                performance_record
 
@@ -79,12 +80,13 @@ def test_process_report_under_pressure(engine_result_message, engine_consumer, d
     host = engine_result_message["input"]["host"]
     ros_reports = [engine_result_message["results"]["reports"][7]]
     system_metadata = engine_result_message["results"]["system"]["metadata"]
-    current_performance_record = copy.copy(performance_record)
+    _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     data = db_get_host(host['id'])
     assert str(data.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == current_performance_record['instance_type']
+        assert data.instance_type == _performance_record['instance_type']
+        assert data.region == _performance_record['region']
         assert data.state == SYSTEM_STATES['INSTANCE_OPTIMIZED_UNDER_PRESSURE']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
                performance_record
@@ -95,12 +97,13 @@ def test_process_report_no_pcp(engine_result_message, engine_consumer, db_setup,
     host = engine_result_message["input"]["host"]
     ros_reports = [engine_result_message["results"]["reports"][7]]
     system_metadata = engine_result_message["results"]["system"]["metadata"]
-    current_performance_record = copy.copy(performance_record)
+    _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     data = db_get_host(host['id'])
     assert str(data.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == current_performance_record['instance_type']
+        assert data.instance_type == _performance_record['instance_type']
+        assert data.region == _performance_record['region']
         assert data.state == SYSTEM_STATES['NO_PCP_DATA']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
                performance_record
@@ -111,28 +114,30 @@ def test_process_report_undersized(engine_result_message, engine_consumer, db_se
     host = engine_result_message["input"]["host"]
     ros_reports = [engine_result_message["results"]["reports"][7]]
     system_metadata = engine_result_message["results"]["system"]["metadata"]
-    current_performance_record = copy.copy(performance_record)
+    _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     data = db_get_host(host['id'])
     assert str(data.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == current_performance_record['instance_type']
+        assert data.instance_type == _performance_record['instance_type']
+        assert data.region == _performance_record['region']
         assert data.state == SYSTEM_STATES['INSTANCE_UNDERSIZED']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
                performance_record
 
 
 def test_process_report_optimized(engine_result_message, engine_consumer, db_setup, performance_record):
-    engine_result_message = engine_result_message("insights-engine-result-undersized.json")
+    engine_result_message = engine_result_message("insights-engine-result-optimized.json")
     host = engine_result_message["input"]["host"]
     ros_reports = []
     system_metadata = engine_result_message["results"]["system"]["metadata"]
-    current_performance_record = copy.copy(performance_record)
+    _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     data = db_get_host(host['id'])
     assert str(data.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == current_performance_record['instance_type']
+        assert data.instance_type == _performance_record['instance_type']
+        assert data.region == _performance_record['region']
         assert data.state == SYSTEM_STATES['OPTIMIZED']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
                performance_record

--- a/tests/test_insights_engine_result_consumer.py
+++ b/tests/test_insights_engine_result_consumer.py
@@ -88,3 +88,35 @@ def test_process_report_under_pressure(engine_result_message, engine_consumer, d
         assert data.state == SYSTEM_STATES['INSTANCE_OPTIMIZED_UNDER_PRESSURE']
         assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
                performance_record
+
+
+def test_process_report_no_pcp(engine_result_message, engine_consumer, db_setup, performance_record):
+    engine_result_message = engine_result_message("insights-engine-result-no-pcp.json")
+    host = engine_result_message["input"]["host"]
+    ros_reports = [engine_result_message["results"]["reports"][7]]
+    system_metadata = engine_result_message["results"]["system"]["metadata"]
+    current_performance_record = copy.copy(performance_record)
+    engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
+    data = db_get_host(host['id'])
+    assert str(data.inventory_id) == host['id']
+    with app.app_context():
+        assert data.instance_type == current_performance_record['instance_type']
+        assert data.state == SYSTEM_STATES['NO_PCP_DATA']
+        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
+               performance_record
+
+
+def test_process_report_undersized(engine_result_message, engine_consumer, db_setup, performance_record):
+    engine_result_message = engine_result_message("insights-engine-result-undersized.json")
+    host = engine_result_message["input"]["host"]
+    ros_reports = [engine_result_message["results"]["reports"][7]]
+    system_metadata = engine_result_message["results"]["system"]["metadata"]
+    current_performance_record = copy.copy(performance_record)
+    engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
+    data = db_get_host(host['id'])
+    assert str(data.inventory_id) == host['id']
+    with app.app_context():
+        assert data.instance_type == current_performance_record['instance_type']
+        assert data.state == SYSTEM_STATES['INSTANCE_UNDERSIZED']
+        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
+               performance_record


### PR DESCRIPTION
Getting `region` value from rule hit won't work for optimized state. Not able to get `region` for NO_PCP_DATA also. Hence, using performance_record to get the `region` value, storing it in `systems` table and discarding it from `performance_record.` Also discarding `instance_type` from performance_record as we already have instance_type column in systems table.
Added tests for no-pcp, undersized and optimized states