### PR TITLE
RHIROS-460 | Util value types on openapi.json

### DIFF
--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -344,10 +344,10 @@
                         "type": "object",
                         "properties": {
                             "memory": {
-                                "type": "number"
+                                "type": "integer"
                             },
                             "cpu": {
-                                "type": "number"
+                                "type": "integer"
                             },
                             "max_io": {
                                 "type": "integer"
@@ -397,10 +397,10 @@
                         "type": "object",
                         "properties": {
                             "memory": {
-                                "type": "number"
+                                "type": "integer"
                             },
                             "cpu": {
-                                "type": "number"
+                                "type": "integer"
                             },
                             "max_io": {
                                 "type": "integer"


### PR DESCRIPTION
Changes:
1. cpu and memory types on SystemDetails schema and SystemItem schema

Reasons:
1. Value types are referred by server on deserialization