### PR TITLE
RHIROS-465 | Move deployment templates to github repository

### DIFF
--- a/saas-templates/_imagestreams.yaml
+++ b/saas-templates/_imagestreams.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+items:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: ros-backend
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/cloudservices/ros-backend:latest
+      importPolicy:
+        scheduled: true
+      name: latest
+      referencePolicy:
+        type: Source
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: ros-backend
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/cloudservices/ros-backend:qa
+      importPolicy:
+        scheduled: true
+      name: qa
+      referencePolicy:
+        type: Source
+kind: List

--- a/saas-templates/ros-backend.yaml
+++ b/saas-templates/ros-backend.yaml
@@ -1,0 +1,184 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ros-backend-deployment-config
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ros-backend
+    name: ros-backend
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8000
+    selector:
+      app: ros-backend
+    type: ClusterIP
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ros-backend
+    name: ros-backend
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{MINIMUM_REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        app: ros-backend
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        annotations:
+          prometheus.io/path: /metrics
+          prometheus.io/port: '8000'
+          prometheus.io/scrape: 'true'
+        labels:
+          app: ros-backend
+        name: ros-backend
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ros-backend
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ros-backend
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - args:
+          - -c
+          - python -m manage db upgrade && python -m manage seed && python -m ros.api.main
+          command:
+          - bash
+          env:
+          - name: INVENTORY_HOST
+            value: ${HOST_INVENTORY_HOST}
+          - name: INVENTORY_PORT
+            value: '8080'
+          - name: ROS_DB_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ros-db
+                optional: false
+          - name: ROS_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ros-db
+                optional: false
+          - name: ROS_DB_HOST
+            valueFrom:
+              secretKeyRef:
+                key: db.host
+                name: ros-db
+                optional: false
+          - name: ROS_DB_PORT
+            valueFrom:
+              secretKeyRef:
+                key: db.port
+                name: ros-db
+                optional: false
+          - name: ROS_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ros-db
+                optional: false
+          - name: RBAC_SVC_URL
+            value: http://${RBAC_HOST}:8080
+          - name: ENABLE_RBAC
+            value: ${ENABLE_RBAC}
+          image: quay.io/cloudservices/ros-backend:${IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/ros/v1/status
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: ros-backend
+          ports:
+          - containerPort: 8000
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/ros/v1/status
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+parameters:
+- name: HOST_INVENTORY_HOST
+  required: true
+  value: insights-inventory.platform-ci.svc
+- description: rbac service host for accessing API within cluster
+  name: RBAC_HOST
+- description: enable rbac. needs to be "True" or "False".
+  name: ENABLE_RBAC
+  value: 'True'
+- description: Minimum Replicas for Autoscaling
+  displayName: Minimum Replicas
+  name: MINIMUM_REPLICAS
+  required: true
+  value: '1'
+- description: Initial cpu request.
+  displayName: CPU Request
+  name: CPU_REQUEST
+  required: true
+  value: 500m
+- description: Initial amount of memory the container will request.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  required: true
+  value: 1Gi
+- description: Maximum amount of memory the Django container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- description: Maximum amount of CPU the build container can use.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  required: true
+  value: '1'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true

--- a/saas-templates/ros-db.yaml
+++ b/saas-templates/ros-db.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: ros
+  template: ros-db
+metadata:
+  name: ros-database-template
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ros
+      template: ros-template
+    name: ros-db
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        name: ros-db
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: ros
+          name: ros-db
+          template: ros-template
+        name: ros-db
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ros
+                  - key: template
+                    operator: In
+                    values:
+                    - ros-template
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ros
+                  - key: template
+                    operator: In
+                    values:
+                    - ros-template
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - env:
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ros-db
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ros-db
+          - name: POSTGRESQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ros-db
+          image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+              - /usr/libexec/check-container
+              - --live
+            failureThreshold: 3
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: ros-db
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /usr/libexec/check-container
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: ${POSTGRESQL_CPU_LIMIT}
+              memory: ${POSTGRESQL_MEMORY_LIMIT}
+            requests:
+              cpu: ${POSTGRESQL_CPU_REQUEST}
+              memory: ${POSTGRESQL_MEMORY_REQUEST}
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: ros-db-data
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+        volumes:
+        - name: ros-db-data
+          persistentVolumeClaim:
+            claimName: ros-db
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: ros
+      template: ros-template
+    name: ros-db
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes the database server
+    labels:
+      app: ros
+      template: ros-template
+    name: ros-db
+  spec:
+    ports:
+    - name: ros-db
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      name: ros-db
+parameters:
+- description: Initial amount of memory the PostgreSQL container will request.
+  displayName: Memory Request (PostgreSQL)
+  name: POSTGRESQL_MEMORY_REQUEST
+  required: true
+  value: 1Gi
+- description: Maximum amount of memory the PostgreSQL container can use.
+  displayName: Memory Limit (PostgreSQL)
+  name: POSTGRESQL_MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- description: Initial amount of CPU the build container will request.
+  displayName: CPU Request
+  name: POSTGRESQL_CPU_REQUEST
+  required: true
+  value: 500m
+- description: Maximum amount of CPU the build container can use.
+  displayName: CPU Limit
+  name: POSTGRESQL_CPU_LIMIT
+  required: true
+  value: '1'
+- description: Volume space available for data, e.g. 512Mi, 2Gi
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 10Gi

--- a/saas-templates/ros-processor.yaml
+++ b/saas-templates/ros-processor.yaml
@@ -1,0 +1,170 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ros-processor-deployment-config
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ros-processor
+    name: ros-processor
+  spec:
+    ports:
+    - name: metrics
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    selector:
+      app: ros-processor
+    type: ClusterIP
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ros-processor
+    name: ros-processor
+  spec:
+    minReadySeconds: 15
+    progressDeadlineSeconds: 600
+    replicas: ${{MINIMUM_REPLICAS}}
+    revisionHistoryLimit: 9
+    selector:
+      matchLabels:
+        app: ros-processor
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        annotations:
+          prometheus.io/path: /metrics
+          prometheus.io/port: '9000'
+          prometheus.io/scrape: 'true'
+        labels:
+          app: ros-processor
+        name: ros-processor
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ros-processor
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - ros-processor
+                topologyKey: kubernetes.io/hostname
+              weight: 99
+        containers:
+        - args:
+          - -c
+          - python -m manage db upgrade && python -m manage seed && python -m ros.processor.main
+          command:
+          - bash
+          env:
+          - name: INVENTORY_HOST
+            value: ${HOST_INVENTORY_HOST}
+          - name: INVENTORY_PORT
+            value: '8080'
+          - name: INSIGHTS_KAFKA_HOST
+            value: ${KAFKA_BOOTSTRAP_HOST}
+          - name: INSIGHTS_KAFKA_PORT
+            value: ${KAFKA_BOOTSTRAP_PORT}
+          - name: METRICS_PORT
+            value: ${METRICS_PORT}
+          - name: ROS_DB_USER
+            valueFrom:
+              secretKeyRef:
+                key: db.user
+                name: ros-db
+                optional: false
+          - name: ROS_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                key: db.password
+                name: ros-db
+                optional: false
+          - name: ROS_DB_HOST
+            valueFrom:
+              secretKeyRef:
+                key: db.host
+                name: ros-db
+                optional: false
+          - name: ROS_DB_PORT
+            valueFrom:
+              secretKeyRef:
+                key: db.port
+                name: ros-db
+                optional: false
+          - name: ROS_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                key: db.name
+                name: ros-db
+                optional: false
+          image: quay.io/cloudservices/ros-backend:${IMAGE_TAG}
+          name: ros-processor
+          ports:
+          - containerPort: ${{METRICS_PORT}}
+            name: metrics
+            protocol: TCP
+          resources:
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        - name: rh-registry-pull
+parameters:
+- name: HOST_INVENTORY_HOST
+  required: true
+  value: insights-inventory.platform-ci.svc
+- name: KAFKA_BOOTSTRAP_HOST
+  required: true
+  value: platform-mq-ci-kafka-bootstrap.platform-mq-ci.svc.cluster.local
+- name: KAFKA_BOOTSTRAP_PORT
+  required: true
+  value: '9092'
+- description: Minimum Replicas for Autoscaling
+  displayName: Minimum Replicas
+  name: MINIMUM_REPLICAS
+  required: true
+  value: '1'
+- description: Initial cpu request.
+  displayName: CPU Request
+  name: CPU_REQUEST
+  required: true
+  value: 500m
+- description: Initial amount of memory the container will request.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  required: true
+  value: 1Gi
+- description: Maximum amount of memory the Django container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- description: Maximum amount of CPU the build container can use.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  required: true
+  value: '1'
+- name: METRICS_PORT
+  value: '9000'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true


### PR DESCRIPTION
### Changes:
1. Created saas_templates folder at root level and added the deployment templates

### References:
https://mailman-int.corp.redhat.com/archives/insights-platform/2022-January/msg00011.html