### PR TITLE
RHIROS-469 | (Cherry-picked) orderByParam is now max_io instead of io, systems endpoint

### DIFF
--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -565,7 +565,7 @@
                         "display_name",
                         "cpu",
                         "memory",
-                        "io",
+                        "max_io",
                         "number_of_suggestions",
                         "state"
                     ]


### PR DESCRIPTION
Changes:
1. Updated orderByParam from io to max_io

Reasons:
1. io is now longer a sortable parameter