### PR TITLE
RHIROS-474 | -1 util values for "Waiting for Data" state

### DIFF
--- a/ros/processor/insights_engine_result_consumer.py
+++ b/ros/processor/insights_engine_result_consumer.py
@@ -125,7 +125,7 @@ class InsightsEngineResultConsumer:
                     display_name=host['display_name'],
                     fqdn=host['fqdn'],
                     rule_hit_details=reports,
-                    number_of_recommendations=rec_count,
+                    number_of_recommendations=-1 if state_key == 'NO_PCP_DATA' else rec_count,
                     state=SYSTEM_STATES[state_key],
                     instance_type=performance_record.get('instance_type'),
                     region=performance_record.get('region')
@@ -152,9 +152,9 @@ class InsightsEngineResultConsumer:
                 else:
                     LOG.debug(f"{self.prefix} - Setting default utilization for performance profile")
                     performance_utilization = {
-                        'memory': 0,
-                        'cpu': 0,
-                        'max_io': 0,
+                        'memory': -1,
+                        'cpu': -1,
+                        'max_io': -1.0,
                         'io': {}
                     }
                 # Following are saved on respective system record

--- a/tests/test_insights_engine_result_consumer.py
+++ b/tests/test_insights_engine_result_consumer.py
@@ -66,14 +66,14 @@ def test_process_report_idle(engine_result_message, engine_consumer, db_setup, p
     system_metadata = engine_result_message["results"]["system"]["metadata"]
     _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
-    data = db_get_host(host['id'])
-    assert str(data.inventory_id) == host['id']
+    system_record = db_get_host(host['id'])
+    assert str(system_record.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == _performance_record['instance_type']
-        assert data.region == _performance_record['region']
-        assert data.state == SYSTEM_STATES['INSTANCE_IDLE']
-        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
-               performance_record
+        assert system_record.instance_type == _performance_record['instance_type']
+        assert system_record.region == _performance_record['region']
+        assert system_record.state == SYSTEM_STATES['INSTANCE_IDLE']
+        assert db.session.query(PerformanceProfile).filter_by(system_id=system_record.id).\
+               first().performance_record == performance_record
 
 
 def test_process_report_under_pressure(engine_result_message, engine_consumer, db_setup, performance_record):
@@ -83,14 +83,14 @@ def test_process_report_under_pressure(engine_result_message, engine_consumer, d
     system_metadata = engine_result_message["results"]["system"]["metadata"]
     _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
-    data = db_get_host(host['id'])
-    assert str(data.inventory_id) == host['id']
+    system_record = db_get_host(host['id'])
+    assert str(system_record.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == _performance_record['instance_type']
-        assert data.region == _performance_record['region']
-        assert data.state == SYSTEM_STATES['INSTANCE_OPTIMIZED_UNDER_PRESSURE']
-        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
-               performance_record
+        assert system_record.instance_type == _performance_record['instance_type']
+        assert system_record.region == _performance_record['region']
+        assert system_record.state == SYSTEM_STATES['INSTANCE_OPTIMIZED_UNDER_PRESSURE']
+        assert db.session.query(PerformanceProfile).filter_by(system_id=system_record.id).\
+               first().performance_record == performance_record
 
 
 def test_process_report_no_pcp(engine_result_message, engine_consumer, db_setup, performance_record):
@@ -100,14 +100,16 @@ def test_process_report_no_pcp(engine_result_message, engine_consumer, db_setup,
     system_metadata = engine_result_message["results"]["system"]["metadata"]
     _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
-    data = db_get_host(host['id'])
-    assert str(data.inventory_id) == host['id']
+    system_record = db_get_host(host['id'])
+    performance_utilization = db.session.query(PerformanceProfile).\
+        filter_by(system_id=system_record.id).first().performance_utilization
+    sample_performance_util_no_pcp = {'cpu': -1, 'memory': -1, 'max_io': -1.0, 'io': {}}
+    assert str(system_record.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == _performance_record['instance_type']
-        assert data.region == _performance_record['region']
-        assert data.state == SYSTEM_STATES['NO_PCP_DATA']
-        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
-               performance_record
+        assert system_record.instance_type == _performance_record['instance_type']
+        assert system_record.region == _performance_record['region']
+        assert system_record.state == SYSTEM_STATES['NO_PCP_DATA']
+        assert performance_utilization == sample_performance_util_no_pcp
 
 
 def test_process_report_undersized(engine_result_message, engine_consumer, db_setup, performance_record):
@@ -117,14 +119,14 @@ def test_process_report_undersized(engine_result_message, engine_consumer, db_se
     system_metadata = engine_result_message["results"]["system"]["metadata"]
     _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
-    data = db_get_host(host['id'])
-    assert str(data.inventory_id) == host['id']
+    system_record = db_get_host(host['id'])
+    assert str(system_record.inventory_id) == host['id']
     with app.app_context():
-        assert data.instance_type == _performance_record['instance_type']
-        assert data.region == _performance_record['region']
-        assert data.state == SYSTEM_STATES['INSTANCE_UNDERSIZED']
-        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
-               performance_record
+        assert system_record.instance_type == _performance_record['instance_type']
+        assert system_record.region == _performance_record['region']
+        assert system_record.state == SYSTEM_STATES['INSTANCE_UNDERSIZED']
+        assert db.session.query(PerformanceProfile).filter_by(system_id=system_record.id).\
+               first().performance_record == performance_record
 
 
 def test_process_report_optimized(engine_result_message, engine_consumer, db_setup, performance_record):
@@ -134,12 +136,12 @@ def test_process_report_optimized(engine_result_message, engine_consumer, db_set
     system_metadata = engine_result_message["results"]["system"]["metadata"]
     _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
-    data = db_get_host(host['id'])
-    assert str(data.inventory_id) == host['id']
+    system_record = db_get_host(host['id'])
+    assert str(system_record.inventory_id) == host['id']
     with app.app_context():
-        assert data.rule_hit_details == ros_reports
-        assert data.instance_type == _performance_record['instance_type']
-        assert data.region == _performance_record['region']
-        assert data.state == SYSTEM_STATES['OPTIMIZED']
-        assert db.session.query(PerformanceProfile).filter_by(system_id=data.id).first().performance_record ==\
-               performance_record
+        assert system_record.rule_hit_details == ros_reports
+        assert system_record.instance_type == _performance_record['instance_type']
+        assert system_record.region == _performance_record['region']
+        assert system_record.state == SYSTEM_STATES['OPTIMIZED']
+        assert db.session.query(PerformanceProfile).filter_by(system_id=system_record.id).\
+               first().performance_record == performance_record


### PR DESCRIPTION
### Changes:
1. no-pcp state stores -1 for util values and `number_of_suggestions`
2. unittests updated

### Reasons:
1. Change helps with the sorting functionality on ROS home page 
2. `0` seems like an inappropriate util value for a system that is Waiting for data