### PR TITLE
RHIROS-391 | Kibana Logging - Renamed client/session keyword for watchtower.CloudWatchLogHandler

### DIFF
--- a/ros/lib/cw_logging.py
+++ b/ros/lib/cw_logging.py
@@ -4,8 +4,8 @@ The logs are then sent to Kibana through an in-place AWS Lambda function.
 Reference: https://consoledot.pages.redhat.com/docs/dev/platform-documentation/tools/logging.html
 """
 
+import boto3
 import watchtower
-from boto3.session import Session
 from botocore.exceptions import ClientError
 
 from ros.lib.config import (
@@ -37,14 +37,15 @@ def commence_cw_log_streaming(stream_name):
         return
 
     try:
-        boto3_session = Session(
+        boto3_client = boto3.client(
+            'cloudwatch',
             aws_access_key_id=AWS_ACCESS_KEY_ID,
             aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
             region_name=AWS_REGION_NAME
         )
 
         watchtower_handler = watchtower.CloudWatchLogHandler(
-            boto3_session=boto3_session,
+            boto3_client=boto3_client,
             log_group=AWS_LOG_GROUP,
             stream_name=stream_name
         )


### PR DESCRIPTION
Fix for the following error on Openshift pods:

```
File "/opt/app-root/src/ros/lib/cw_logging.py", line 46, in commence_cw_log_streaming
watchtower_handler = watchtower.CloudWatchLogHandler(
File "/opt/app-root/lib64/python3.8/site-packages/watchtower/__init__.py", line 193, in __init__
super().__init__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'boto3_session'
```

Docs do suggest to use `boto_session` :shrug: 

References:

1. https://github.com/RedHatInsights/vmaas/blob/master/vmaas/common/logging_utils.py#L64
2. https://stackoverflow.com/questions/70954418/django-logging-with-watchtower-got-an-unexpected-keyword-argument-in-handler

Related to #163 