### PR TITLE
RHIROS-391 | Cloudwatch Logging - watchtower/boto3 errors

### DIFF
--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -85,3 +85,4 @@ GARBAGE_COLLECTION_INTERVAL = os.getenv("GARBAGE_COLLECTION_INTERVAL", 86400)
 # Number of days after which data is considered to be outdated.
 DAYS_UNTIL_STALE = os.getenv("DAYS_UNTIL_STALE", 14)
 INSTANCE_PRICE_UNIT = 'USD/hour'
+CW_LOGGING_FORMAT = '%(asctime)s - %(levelname)s  - %(funcName)s - %(message)s'

--- a/ros/lib/cw_logging.py
+++ b/ros/lib/cw_logging.py
@@ -3,9 +3,10 @@ This module helps with streaming app logs to AWS CloudWatch.
 The logs are then sent to Kibana through an in-place AWS Lambda function.
 Reference: https://consoledot.pages.redhat.com/docs/dev/platform-documentation/tools/logging.html
 """
+import logging
 
+import boto3
 import watchtower
-from boto3 import Session
 from botocore.exceptions import ClientError
 
 from ros.lib.config import (
@@ -18,7 +19,8 @@ if CW_ENABLED is True:
         AWS_ACCESS_KEY_ID,
         AWS_SECRET_ACCESS_KEY,
         AWS_REGION_NAME,
-        AWS_LOG_GROUP
+        AWS_LOG_GROUP,
+        CW_LOGGING_FORMAT,
     )
 
 
@@ -27,6 +29,7 @@ module_prefix = 'CLOUDWATCH LOGGING'
 
 def commence_cw_log_streaming(stream_name):
     logger = get_logger(__name__)
+    root_logger = logging.getLogger()
 
     if CW_ENABLED is False:
         logger.warning(f"{module_prefix} - Disabled")
@@ -37,19 +40,22 @@ def commence_cw_log_streaming(stream_name):
         return
 
     try:
-        boto3_session = Session(
+        boto3_client = boto3.client(
+            'logs',
             aws_access_key_id=AWS_ACCESS_KEY_ID,
             aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
             region_name=AWS_REGION_NAME
         )
 
         watchtower_handler = watchtower.CloudWatchLogHandler(
-            boto3_client=boto3_session,
+            boto3_client=boto3_client,
             log_group=AWS_LOG_GROUP,
             stream_name=stream_name
         )
     except ClientError as e:
         logger.exception(f"{module_prefix} - Failed; error: {e}")
     else:
-        logger.addHandler(watchtower_handler)
-        logger.info(f"{module_prefix} - Streaming in-progress")
+        logger.info(f"{module_prefix} - Streaming in progress - Log group: {AWS_LOG_GROUP}")
+        watchtower_handler.setLevel(logging.INFO)
+        watchtower_handler.setFormatter(logging.Formatter(fmt=CW_LOGGING_FORMAT))
+        root_logger.addHandler(watchtower_handler)


### PR DESCRIPTION
### Changes:
1. Replaced Session with boto3.client, service name for the same needs to be 'logs'
2. watchtower handler now being added to root logger
3. watchtower handler has its own formatter

### Additional:
* Independently tested with custom flask app logging and private aws account

Related to #190 #189 