### PR TITLE
RHIROS-471 | ROS Base Image update - ubi8/ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM registry.redhat.io/rhscl/python-38-rhel7
+FROM registry.redhat.io/ubi8/ubi-minimal
 
-COPY Pipfile Pipfile.lock manage.py seed.py ${APP_ROOT}/src/
+WORKDIR /app_root/src
 
-COPY ros ${APP_ROOT}/src/ros/
-COPY migrations ${APP_ROOT}/src/migrations/
-COPY seed.d ${APP_ROOT}/src/seed.d/
-RUN pip install --upgrade pip && \
-    pip install pipenv && \
+COPY Pipfile Pipfile.lock manage.py seed.py ./
+
+RUN microdnf install --disableplugin=subscription-manager --nodocs -y python38 tar gzip
+
+COPY ros ros
+COPY migrations migrations
+COPY seed.d seed.d
+
+RUN pip3 install --upgrade pip setuptools wheel && \
+    pip3 install pipenv && \
     pipenv install --system --deploy --ignore-pipfile


### PR DESCRIPTION
### Changes:
1. `Dockerfile` changes

### Reasons:
1. An official and minimal image is preferable
2. Helps with faster mitigation of security concerns

### Additional:

A sample image has been pushed at `quay.io/sdutta/ros_base_ubi8_api:latest`
Awaiting security analysis on the same, currently queued.

### Testing:
Here's a version of the source code with the updated Dockerfile, along with a docker-compose file
for the ease of testing.

[ros_base_ubi8.zip](https://github.com/RedHatInsights/ros-backend/files/8832276/ros_base_ubi8.zip)

The idea is to spin up an API container successfully, then

- Check if the urls are responsive
- Exec into the container and check if any insecure packages are available in the same

Steps:

1. Unzip the file
2. `cd ros_base_ubi8/`
3. `docker-compose up --build`

Container should be ready now.

**Note**: 75% of the security cards are linked to the base image update JIRA card, and steps used to verify the same has also been shared in each card.



