### PR TITLE
RHIROS-573,574,575,601,576,577 - Historical data support

### DIFF
--- a/migrations/versions/015d7d1fea52_update_performance_profile_table.py
+++ b/migrations/versions/015d7d1fea52_update_performance_profile_table.py
@@ -1,0 +1,47 @@
+"""update performance profile table
+
+Revision ID: 015d7d1fea52
+Revises: 605a688d0cd2
+Create Date: 2022-03-23 15:48:26.160344
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '015d7d1fea52'
+down_revision = '605a688d0cd2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'performance_profile',
+        sa.Column('number_of_recommendations', sa.Integer(), nullable=True))
+    op.add_column(
+        'performance_profile',
+        sa.Column('state', sa.String(length=25), nullable=True))
+    op.add_column(
+        'performance_profile',
+        sa.Column('operating_system',
+                  postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column(
+        'performance_profile',
+        sa.Column('rule_hit_details',
+                  postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.alter_column(
+        'performance_profile', 'report_date',
+        existing_type=sa.Date(), type_=sa.DateTime(timezone=True))
+
+
+def downgrade():
+    op.drop_column('performance_profile', 'number_of_recommendations')
+    op.drop_column('performance_profile', 'state')
+    op.drop_column('performance_profile', 'operating_system')
+    op.drop_column('performance_profile', 'rule_hit_details')
+    op.alter_column(
+        'performance_profile', 'report_date',
+        existing_type=sa.DateTime(timezone=True), type_=sa.Date())

--- a/migrations/versions/26a16593ec96_remove_columns_from_systems.py
+++ b/migrations/versions/26a16593ec96_remove_columns_from_systems.py
@@ -1,0 +1,32 @@
+"""remove columns from systems
+
+Revision ID: 26a16593ec96
+Revises: 3d3a1981593c
+Create Date: 2022-03-24 01:24:52.670825
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = '26a16593ec96'
+down_revision = '3d3a1981593c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('systems', 'rule_hit_details')
+    op.drop_column('systems', 'number_of_recommendations')
+
+
+def downgrade():
+    op.add_column(
+        'systems',
+        sa.Column('rule_hit_details',
+                  JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column(
+        'systems',
+        sa.Column('number_of_recommendations',
+                  sa.Integer(), nullable=True))

--- a/migrations/versions/3d3a1981593c_populate_fields_from_systems_to_.py
+++ b/migrations/versions/3d3a1981593c_populate_fields_from_systems_to_.py
@@ -1,0 +1,88 @@
+"""populate fields from systems to performance profile
+
+Revision ID: 3d3a1981593c
+Revises: 015d7d1fea52
+Create Date: 2022-03-23 23:45:14.430980
+
+"""
+from migrations.session_helpers import session
+from sqlalchemy import func, DateTime, Integer, String, Column
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.ext.declarative import declarative_base
+from ros.lib.utils import get_or_create
+
+# revision identifiers, used by Alembic.
+revision = '3d3a1981593c'
+down_revision = '015d7d1fea52'
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+
+
+class PerformanceProfile(Base):
+    __tablename__ = "performance_profile"
+    system_id = Column(Integer, primary_key=True)
+    report_date = Column(DateTime, primary_key=True)
+    rule_hit_details = Column(JSONB)
+    state = Column(String(25))
+    number_of_recommendations = Column(Integer)
+    operating_system = Column(JSONB)
+
+
+class System(Base):
+    __tablename__ = 'systems'
+    id = Column(Integer, primary_key=True)
+    inventory_id = Column(UUID(as_uuid=True), nullable=False)
+    rule_hit_details = Column(JSONB)
+    state = Column(String(25))
+    number_of_recommendations = Column(Integer)
+    operating_system = Column(JSONB)
+
+
+def populate_fields_data_to_performance_profile():
+    with session() as session_obj:
+        last_reported = (
+            session_obj.query(
+                PerformanceProfile.system_id,
+                func.max(PerformanceProfile.report_date).label('max_date')
+            ).group_by(PerformanceProfile.system_id).subquery()
+        )
+
+        query = (
+            session_obj.query(PerformanceProfile, System)
+            .join(
+                last_reported, (
+                    last_reported.c.max_date == PerformanceProfile.report_date
+                ) & (
+                    PerformanceProfile.system_id == last_reported.c.system_id))
+            .join(System, System.id == last_reported.c.system_id)
+        )
+
+        pp_results = query.all()
+        for record in pp_results:
+            try:
+                get_or_create(
+                    session_obj, PerformanceProfile,
+                    ['system_id', 'report_date'],
+                    system_id=record.System.id,
+                    report_date=record.PerformanceProfile.report_date,
+                    operating_system=record.System.operating_system,
+                    state=record.System.state,
+                    rule_hit_details=record.System.rule_hit_details,
+                    number_of_recommendations=record.System.number_of_recommendations
+                )
+            except Exception as err:
+                print(
+                    'Failed to update performance_profile with '
+                    f'system_id={record.System.id} and error={err}'
+                )
+                raise
+
+
+def upgrade():
+    populate_fields_data_to_performance_profile()
+
+
+def downgrade():
+    pass

--- a/migrations/versions/457844090fad_set_keys_on_performance_profile_history.py
+++ b/migrations/versions/457844090fad_set_keys_on_performance_profile_history.py
@@ -1,0 +1,37 @@
+"""set keys on performance profile history
+
+Revision ID: 457844090fad
+Revises: 8c6f4554d24d
+Create Date: 2022-03-24 16:34:39.897983
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '457844090fad'
+down_revision = '8c6f4554d24d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_primary_key(
+        "pk_performance_profile_history", "performance_profile_history",
+        ["system_id", "report_date"]
+    )
+
+    op.create_foreign_key(
+        'fk_performance_profile_history_systems',
+        'performance_profile_history', 'systems',
+        ['system_id'], ['id'], ondelete='CASCADE')
+
+
+def downgrade():
+    op.drop_constraint(
+        'pk_performance_profile_history',
+        'performance_profile_history', type_='primary')
+    op.drop_constraint(
+        'fk_performance_profile_history_systems',
+        'performance_profile_history', type_='foreignkey')

--- a/migrations/versions/77fdc857c94f_alter_pk_on_performance_profile.py
+++ b/migrations/versions/77fdc857c94f_alter_pk_on_performance_profile.py
@@ -1,0 +1,40 @@
+"""alter pk on performance profile
+
+Revision ID: 77fdc857c94f
+Revises: ccf59577aca2
+Create Date: 2022-03-25 01:18:21.000251
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '77fdc857c94f'
+down_revision = 'ccf59577aca2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        'ALTER TABLE performance_profile DROP '
+        ' CONSTRAINT performance_profile_pkey'
+    )
+    op.create_primary_key(
+        'performance_profile_pkey',
+        'performance_profile',
+        ['system_id']
+    )
+
+
+def downgrade():
+    op.execute(
+        'ALTER TABLE performance_profile DROP '
+        ' CONSTRAINT performance_profile_pkey'
+    )
+    op.create_primary_key(
+        'performance_profile_pkey',
+        'performance_profile',
+        ['system_id', 'report_date']
+    )

--- a/migrations/versions/8c6f4554d24d_create_performance_profile_history.py
+++ b/migrations/versions/8c6f4554d24d_create_performance_profile_history.py
@@ -1,0 +1,33 @@
+"""create performance profile history
+
+Revision ID: 8c6f4554d24d
+Revises: 26a16593ec96
+Create Date: 2022-03-24 13:39:41.695476
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '8c6f4554d24d'
+down_revision = '26a16593ec96'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    try:
+        op.execute(
+            'CREATE TABLE performance_profile_history AS TABLE performance_profile'
+        )
+    except Exception as err:
+        print(
+            "Failed to create performance_profile_history with error=%s",
+            err
+        )
+        raise
+
+
+def downgrade():
+    op.drop_table('performance_profile_history')

--- a/migrations/versions/ccf59577aca2_keep_last_reported_in_perf_profile.py
+++ b/migrations/versions/ccf59577aca2_keep_last_reported_in_perf_profile.py
@@ -1,0 +1,51 @@
+"""keep last reported in perf profile
+
+Revision ID: ccf59577aca2
+Revises: 457844090fad
+Create Date: 2022-03-24 21:02:10.471949
+
+"""
+from migrations.session_helpers import session
+from sqlalchemy import func, tuple_, DateTime, Integer, Column
+from sqlalchemy.ext.declarative import declarative_base
+
+# revision identifiers, used by Alembic.
+revision = 'ccf59577aca2'
+down_revision = '457844090fad'
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+
+
+class PerformanceProfile(Base):
+    __tablename__ = "performance_profile"
+    system_id = Column(Integer, primary_key=True)
+    report_date = Column(DateTime, primary_key=True)
+
+
+def upgrade():
+    with session() as session_obj:
+        last_reported = (
+            session_obj.query(
+                PerformanceProfile.system_id,
+                func.max(PerformanceProfile.report_date).label('max_date')
+            ).group_by(PerformanceProfile.system_id).all()
+        )
+        if last_reported:
+            rows_deleted = (
+                session_obj.query(PerformanceProfile)
+                .filter(
+                    tuple_(
+                        PerformanceProfile.system_id,
+                        PerformanceProfile.report_date
+                    ).notin_(last_reported)
+                ).delete(synchronize_session='fetch')
+            )
+            print(
+                f'Rows deleted from PerformanceProfile table={rows_deleted}'
+            )
+
+
+def downgrade():
+    pass

--- a/ros/api/v1/call_to_action.py
+++ b/ros/api/v1/call_to_action.py
@@ -13,7 +13,6 @@ class CallToActionApi(Resource):
         query = (
             db.session.query(PerformanceProfile.system_id)
             .filter(PerformanceProfile.system_id.in_(system_query.subquery()))
-            .distinct()
         )
         total_system_count = query.count()
 

--- a/ros/api/v1/call_to_action.py
+++ b/ros/api/v1/call_to_action.py
@@ -3,13 +3,13 @@ from flask import request
 from ros.lib.utils import (
     identity, system_ids_by_account)
 from ros.lib.models import (
-    System, PerformanceProfile, db)
+    PerformanceProfile, db)
 
 
 class CallToActionApi(Resource):
     def get(self):
         account_number = identity(request)['identity']['account_number']
-        system_query = system_ids_by_account(account_number).filter(System.number_of_recommendations > 0)
+        system_query = system_ids_by_account(account_number).filter(PerformanceProfile.number_of_recommendations > 0)
         query = (
             db.session.query(PerformanceProfile.system_id)
             .filter(PerformanceProfile.system_id.in_(system_query.subquery()))

--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -26,9 +26,7 @@ SYSTEM_COLUMNS = [
     'display_name',
     'instance_type',
     'cloud_provider',
-    'rule_hit_details',
     'state',
-    'number_of_recommendations',
     'fqdn',
     'operating_system',
 ]
@@ -45,7 +43,7 @@ class IsROSConfiguredApi(Resource):
             .distinct()
         )
         system_count = query.count()
-        systems_with_suggestions = query.filter(System.number_of_recommendations > 0).count()
+        systems_with_suggestions = query.filter(PerformanceProfile.number_of_recommendations > 0).count()
         systems_waiting_for_data = query.filter(System.state == 'Waiting for data').count()
 
         if system_count <= 0:
@@ -154,6 +152,7 @@ class HostsApi(Resource):
                 host['idling_time'] = row.PerformanceProfile.idling_time
                 host['os'] = row.System.deserialize_host_os_data
                 host['report_date'] = row.PerformanceProfile.report_date
+                host['number_of_recommendations'] = row.PerformanceProfile.number_of_recommendations
                 hosts.append(host)
             except Exception as err:
                 LOG.error(
@@ -290,6 +289,7 @@ class HostDetailsApi(Resource):
             record['report_date'] = profile.report_date
             record['idling_time'] = profile.idling_time
             record['os'] = system.deserialize_host_os_data
+            record['number_of_recommendations'] = profile.number_of_recommendations
         else:
             abort(404, message="System {} doesn't exist"
                   .format(host_id))

--- a/ros/api/v1/recommendations.py
+++ b/ros/api/v1/recommendations.py
@@ -1,4 +1,4 @@
-from ros.lib.models import Rule, RhAccount, System, db
+from ros.lib.models import Rule, RhAccount, System, db, PerformanceProfile
 from ros.lib.utils import is_valid_uuid, identity
 from ros.lib.config import INSTANCE_PRICE_UNIT
 from flask_restful import Resource, abort, fields, marshal_with
@@ -44,7 +44,14 @@ class RecommendationsApi(Resource):
         if not system:
             abort(404, message="host with id {} doesn't exist"
                   .format(host_id))
-        rule_hits = system.rule_hit_details
+
+        profile = PerformanceProfile.query.filter_by(system_id=system.id).first()
+        if not profile:
+            abort(
+                404,
+                message="No records for host with id {} doesn't exist".format(host_id))
+
+        rule_hits = profile.rule_hit_details
         recommendations_list = []
         rules_columns = ['rule_id', 'description', 'reason', 'resolution', 'condition']
         if rule_hits:

--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -83,6 +83,6 @@ ENABLE_RBAC = str_to_bool(os.getenv("ENABLE_RBAC", "False"))
 # Time interval after which garbage collector is involved to check for outdated data.
 GARBAGE_COLLECTION_INTERVAL = os.getenv("GARBAGE_COLLECTION_INTERVAL", 86400)
 # Number of days after which data is considered to be outdated.
-DAYS_UNTIL_STALE = os.getenv("DAYS_UNTIL_STALE", 14)
+DAYS_UNTIL_STALE = os.getenv("DAYS_UNTIL_STALE", 45)
 INSTANCE_PRICE_UNIT = 'USD/hour'
 CW_LOGGING_FORMAT = '%(asctime)s - %(levelname)s  - %(funcName)s - %(message)s'

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -1,4 +1,3 @@
-from datetime import date
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 import datetime
@@ -10,10 +9,14 @@ db = SQLAlchemy()
 class PerformanceProfile(db.Model):
     performance_record = db.Column(JSONB)
     performance_utilization = db.Column(JSONB)
-    report_date = db.Column(db.Date, default=date.today())
+    report_date = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     system_id = db.Column(db.Integer)
+    state = db.Column(db.String(25))
+    operating_system = db.Column(JSONB)
+    rule_hit_details = db.Column(JSONB)
+    number_of_recommendations = db.Column(db.Integer)
     __table_args__ = (
-        db.PrimaryKeyConstraint('system_id', 'report_date', name='performance_profile_pkey'),
+        db.PrimaryKeyConstraint('system_id', name='performance_profile_pkey'),
         db.ForeignKeyConstraint(
             ['system_id'], ['systems.id'],
             name='performance_profile_system_id_fkey',
@@ -37,9 +40,7 @@ class System(db.Model):
     fqdn = db.Column(db.String(100))
     cloud_provider = db.Column(db.String(25))
     instance_type = db.Column(db.String(25))
-    rule_hit_details = db.Column(JSONB)
     state = db.Column(db.String(25))
-    number_of_recommendations = db.Column(db.Integer)
     stale_timestamp = db.Column(db.DateTime(timezone=True))
     region = db.Column(db.String(25))
     operating_system = db.Column(JSONB)

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -7,17 +7,15 @@ db = SQLAlchemy()
 
 
 class PerformanceProfile(db.Model):
-    state = db.Column(db.String(25))
-    operating_system = db.Column(JSONB)
-    rule_hit_details = db.Column(JSONB)
     performance_record = db.Column(JSONB)
     performance_utilization = db.Column(JSONB)
-    report_date = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-    system_id = db.Column(db.Integer)
+    report_date = db.Column(
+        db.DateTime(timezone=True), default=datetime.datetime.utcnow)
     state = db.Column(db.String(25))
     operating_system = db.Column(JSONB)
     rule_hit_details = db.Column(JSONB)
     number_of_recommendations = db.Column(db.Integer)
+    system_id = db.Column(db.Integer)
     __table_args__ = (
         db.PrimaryKeyConstraint('system_id', name='performance_profile_pkey'),
         db.ForeignKeyConstraint(
@@ -32,6 +30,25 @@ class PerformanceProfile(db.Model):
             idling_percent = ((float(self.performance_record['kernel.all.cpu.idle']) * 100)
                               / int(self.performance_record['total_cpus']))
             return "%0.2f" % idling_percent
+
+
+class PerformanceProfileHistory(db.Model):
+    performance_record = db.Column(JSONB)
+    performance_utilization = db.Column(JSONB)
+    report_date = db.Column(
+        db.DateTime(timezone=True), default=datetime.datetime.utcnow)
+    state = db.Column(db.String(25))
+    operating_system = db.Column(JSONB)
+    rule_hit_details = db.Column(JSONB)
+    number_of_recommendations = db.Column(db.Integer)
+    system_id = db.Column(db.Integer)
+    __table_args__ = (
+        db.PrimaryKeyConstraint('system_id', 'report_date', name='pk_performance_profile_history'),
+        db.ForeignKeyConstraint(
+            ['system_id'], ['systems.id'],
+            name='fk_performance_profile_history_systems',
+            ondelete='CASCADE'),
+    )
 
 
 class System(db.Model):

--- a/ros/lib/models.py
+++ b/ros/lib/models.py
@@ -7,6 +7,9 @@ db = SQLAlchemy()
 
 
 class PerformanceProfile(db.Model):
+    state = db.Column(db.String(25))
+    operating_system = db.Column(JSONB)
+    rule_hit_details = db.Column(JSONB)
     performance_record = db.Column(JSONB)
     performance_utilization = db.Column(JSONB)
     report_date = db.Column(db.DateTime, default=datetime.datetime.utcnow)

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -4,7 +4,8 @@ import json
 from flask import jsonify, make_response
 from flask_restful import abort
 import ast as type_evaluation
-from ros.lib.models import RhAccount, System, db
+from ros.lib.models import (RhAccount, System, PerformanceProfile,
+                            PerformanceProfileHistory, db)
 
 
 def is_valid_uuid(val):
@@ -109,3 +110,19 @@ def sort_io_dict(performance_utilization: dict):
 def system_ids_by_account(account_number):
     account_query = db.session.query(RhAccount.id).filter(RhAccount.account == account_number).subquery()
     return db.session.query(System.id).filter(System.account_id.in_(account_query))
+
+
+def create_performance_profile(session, system_id, fields):
+    """This method deletes an old entry from performance_profile &
+       inserts latest data inside performance_profile as well as
+       performance_profile_history table.
+    """
+    fields = {} if fields is None else fields
+    delete_record(session, PerformanceProfile, system_id=system_id)
+    get_or_create(
+        session, PerformanceProfile, 'system_id', **fields
+    )
+    get_or_create(
+        session, PerformanceProfileHistory,
+        ['system_id', 'report_date'], **fields
+    )

--- a/ros/processor/insights_engine_result_consumer.py
+++ b/ros/processor/insights_engine_result_consumer.py
@@ -11,7 +11,7 @@ from ros.lib.models import RhAccount, System
 from ros.lib.utils import (
     get_or_create,
     cast_iops_as_float,
-    create_performance_profile,
+    insert_performance_profiles,
     validate_type
 )
 from confluent_kafka import Consumer, KafkaException
@@ -177,7 +177,7 @@ class InsightsEngineResultConsumer:
                     "state": SYSTEM_STATES[state_key],
                     "operating_system": system.operating_system
                 }
-                create_performance_profile(
+                insert_performance_profiles(
                     db.session, system.id, pprofile_fields)
                 LOG.info(
                     f"{self.prefix} - Performance profile created/updated successfully for the system: {host['id']}"

--- a/ros/processor/insights_engine_result_consumer.py
+++ b/ros/processor/insights_engine_result_consumer.py
@@ -124,8 +124,6 @@ class InsightsEngineResultConsumer:
                     inventory_id=host['id'],
                     display_name=host['display_name'],
                     fqdn=host['fqdn'],
-                    rule_hit_details=reports,
-                    number_of_recommendations=-1 if state_key == 'NO_PCP_DATA' else rec_count,
                     state=SYSTEM_STATES[state_key],
                     instance_type=performance_record.get('instance_type'),
                     region=performance_record.get('region'),
@@ -162,11 +160,14 @@ class InsightsEngineResultConsumer:
                 del performance_record['region']
 
                 get_or_create(
-                    db.session, PerformanceProfile, ['system_id', 'report_date'],
+                    db.session, PerformanceProfile, 'system_id',
                     system_id=system.id,
                     performance_record=performance_record,
                     performance_utilization=performance_utilization,
-                    report_date=datetime.datetime.utcnow().date()
+                    report_date=datetime.datetime.utcnow().date(),
+                    rule_hit_details=reports,
+                    number_of_recommendations=-1 if state_key == 'NO_PCP_DATA' else rec_count,
+                    state=SYSTEM_STATES[state_key]
                 )
                 LOG.info(
                     f"{self.prefix} - Performance profile created/updated successfully for the system: {host['id']}"

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -3,7 +3,7 @@ import json
 from confluent_kafka import Consumer, KafkaException
 from ros.lib.config import INSIGHTS_KAFKA_ADDRESS, INVENTORY_EVENTS_TOPIC, GROUP_ID, get_logger
 from ros.lib.app import app, db
-from ros.lib.models import RhAccount, System, PerformanceProfile
+from ros.lib.models import RhAccount, System
 from ros.lib.utils import get_or_create
 from ros.processor.metrics import (processor_requests_success,
                                    processor_requests_failures,
@@ -152,11 +152,6 @@ class InventoryEventsConsumer:
                 }
                 system = get_or_create(db.session, System, 'inventory_id', **system_fields)
 
-                get_or_create(
-                    db.session, PerformanceProfile, 'system_id',
-                    system_id=system.id,
-                    operating_system=host['system_profile']['operating_system']
-                )
                 # Commit changes
                 db.session.commit()
                 processor_requests_success.labels(

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -3,7 +3,7 @@ import json
 from confluent_kafka import Consumer, KafkaException
 from ros.lib.config import INSIGHTS_KAFKA_ADDRESS, INVENTORY_EVENTS_TOPIC, GROUP_ID, get_logger
 from ros.lib.app import app, db
-from ros.lib.models import RhAccount, System
+from ros.lib.models import RhAccount, System, PerformanceProfile
 from ros.lib.utils import get_or_create
 from ros.processor.metrics import (processor_requests_success,
                                    processor_requests_failures,
@@ -152,6 +152,11 @@ class InventoryEventsConsumer:
                 }
                 system = get_or_create(db.session, System, 'inventory_id', **system_fields)
 
+                get_or_create(
+                    db.session, PerformanceProfile, 'system_id',
+                    system_id=system.id,
+                    operating_system=host['system_profile']['operating_system']
+                )
                 # Commit changes
                 db.session.commit()
                 processor_requests_success.labels(

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from ros.lib.app import app, db
 from sqlalchemy_utils import database_exists, create_database, drop_database
-from ros.lib.models import RhAccount, System, PerformanceProfile, Rule
+from ros.lib.models import RhAccount, System, PerformanceProfile, Rule, PerformanceProfileHistory
 
 
 @pytest.fixture(scope="session")
@@ -53,41 +53,9 @@ def db_create_system(db_create_account):
         cloud_provider='aws',
         instance_type='t2.micro',
         state='Idling',
-        number_of_recommendations=1,
         region='ap-south-1',
         operating_system={"name": "RHEL", "major": 8, "minor": 4},
-        rule_hit_details=[{
-          "key": "INSTANCE_IDLE",
-          "tags": [],
-          "type": "rule",
-          "links": {
-            "kcs": [],
-            "jira": [
-              "https://issues.redhat.com/browse/CEECBA-5875"
-            ]
-          },
-          "details": {
-            "rhel": "8.4",
-            "type": "rule",
-            "price": 0.0116,
-            "region": "us-east-1",
-            "summary": [
-              "System is IDLE"
-            ],
-            "error_key": "INSTANCE_IDLE",
-            "candidates": [
-              [
-                "t2.nano",
-                0.0058
-              ]
-            ],
-            "instance_type": "t2.micro",
-            "cloud_provider": "Amazon Web Services"
-          },
-          "rule_id": "ros_instance_evaluation|INSTANCE_IDLE",
-          "component": "telemetry.rules.plugins.ros.ros_instance_evaluation.report",
-          "system_id": "ee0b9978-fe1b-4191-8408-cbadbd47f7a3"
-        }]
+
     )
 
     db.session.add(system)
@@ -144,11 +112,139 @@ def db_create_performance_profile():
     performance_utilization = {"io": {"xvda": 314}, "cpu": 0, "max_io": 314, "memory": 0}
     performance_profile = PerformanceProfile(
         system_id=1,
+        state='Idling',
+        operating_system={"name": "RHEL", "major": 8, "minor": 4},
         performance_record=performance_record,
         performance_utilization=performance_utilization,
-        report_date=datetime.datetime.utcnow().date()
+        report_date=datetime.datetime.utcnow(),
+        number_of_recommendations=1,
+        rule_hit_details=[{
+          "key": "INSTANCE_IDLE",
+          "tags": [],
+          "type": "rule",
+          "links": {
+            "kcs": [],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5875"
+            ]
+          },
+          "details": {
+            "rhel": "8.4",
+            "type": "rule",
+            "price": 0.0116,
+            "region": "us-east-1",
+            "summary": [
+              "System is IDLE"
+            ],
+            "error_key": "INSTANCE_IDLE",
+            "candidates": [
+              [
+                "t2.nano",
+                0.0058
+              ]
+            ],
+            "instance_type": "t2.micro",
+            "cloud_provider": "Amazon Web Services"
+          },
+          "rule_id": "ros_instance_evaluation|INSTANCE_IDLE",
+          "component": "telemetry.rules.plugins.ros.ros_instance_evaluation.report",
+          "system_id": "ee0b9978-fe1b-4191-8408-cbadbd47f7a3"
+        }]
     )
     db.session.add(performance_profile)
+    db.session.commit()
+
+
+@pytest.fixture(scope="function")
+def db_create_performance_profile_history():
+    # dummy record values
+    performance_record = {
+      "hinv.ncpu": 2.0,
+      "total_cpus": 1,
+      "mem.physmem": 825740.0,
+      "instance_type": "t2.micro",
+      "disk.dev.total": {
+        "xvda": {
+          "val": 0.314,
+          "units": "count / sec"
+        }
+      },
+      "mem.util.available": 825040.0,
+      "kernel.all.cpu.idle": 1.997,
+      "kernel.all.pressure.io.full.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.io.some.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.cpu.some.avg": {
+        "1 minute": {
+          "val": 0.06,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.memory.full.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.memory.some.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      }
+    }
+    performance_utilization = {"io": {"xvda": 314}, "cpu": 0, "max_io": 314, "memory": 0}
+    performance_profile_history = PerformanceProfileHistory(
+        system_id=1,
+        state='Idling',
+        operating_system={"name": "RHEL", "major": 8, "minor": 4},
+        performance_record=performance_record,
+        performance_utilization=performance_utilization,
+        report_date=datetime.datetime.utcnow(),
+        number_of_recommendations=1,
+        rule_hit_details=[{
+          "key": "INSTANCE_IDLE",
+          "tags": [],
+          "type": "rule",
+          "links": {
+            "kcs": [],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5875"
+            ]
+          },
+          "details": {
+            "rhel": "8.4",
+            "type": "rule",
+            "price": 0.0116,
+            "region": "us-east-1",
+            "summary": [
+              "System is IDLE"
+            ],
+            "error_key": "INSTANCE_IDLE",
+            "candidates": [
+              [
+                "t2.nano",
+                0.0058
+              ]
+            ],
+            "instance_type": "t2.micro",
+            "cloud_provider": "Amazon Web Services"
+          },
+          "rule_id": "ros_instance_evaluation|INSTANCE_IDLE",
+          "component": "telemetry.rules.plugins.ros.ros_instance_evaluation.report",
+          "system_id": "ee0b9978-fe1b-4191-8408-cbadbd47f7a3"
+        }]
+    )
+    db.session.add(performance_profile_history)
     db.session.commit()
 
 

--- a/tests/helpers/db_helper.py
+++ b/tests/helpers/db_helper.py
@@ -1,6 +1,10 @@
-from ros.lib.models import System
+from ros.lib.models import System, PerformanceProfile
 from ros.lib.app import db
 
 
 def db_get_host(host_id):
     return db.session.query(System).filter_by(inventory_id=host_id).first()
+
+
+def db_get_perf_profile(system_id):
+    return db.session.query(PerformanceProfile).filter_by(system_id=system_id).first()

--- a/tests/helpers/db_helper.py
+++ b/tests/helpers/db_helper.py
@@ -1,4 +1,4 @@
-from ros.lib.models import System, PerformanceProfile
+from ros.lib.models import System
 from ros.lib.app import db
 
 
@@ -6,5 +6,9 @@ def db_get_host(host_id):
     return db.session.query(System).filter_by(inventory_id=host_id).first()
 
 
-def db_get_perf_profile(system_id):
-    return db.session.query(PerformanceProfile).filter_by(system_id=system_id).first()
+def db_get_record(model, **filters):
+    return db.session.query(model).filter_by(**filters).first()
+
+
+def db_get_records(model, **filters):
+    return db.session.query(model).filter_by(**filters)

--- a/tests/test_garbage_collector.py
+++ b/tests/test_garbage_collector.py
@@ -1,0 +1,55 @@
+import pytest
+from datetime import datetime
+from datetime import timedelta
+from ros.lib.models import db, PerformanceProfile, PerformanceProfileHistory
+from ros.processor.garbage_collector import GarbageCollector
+from tests.helpers.db_helper import db_get_records
+
+
+@pytest.fixture
+def garbage_collector():
+    return GarbageCollector()
+
+
+def test_remove_outdated_data(
+        garbage_collector,
+        db_setup,
+        db_create_system,
+        db_create_performance_profile,
+        db_create_performance_profile_history):
+    system_id = 1
+    date_to_set = datetime.utcnow() - timedelta(days=46)
+    profile_records = db_get_records(PerformanceProfile, system_id=system_id)
+    history_records = db_get_records(PerformanceProfileHistory, system_id=system_id)
+    total_profile_records_before = profile_records.count()
+    total_history_records_before = history_records.count()
+    assert total_profile_records_before == 1
+    assert total_history_records_before == 1
+    history_rec = history_records.first()
+    pprofile_rec = profile_records.first()
+    history_rec.report_date = date_to_set
+    pprofile_rec.report_date = date_to_set
+    db.session.commit()
+    garbage_collector.remove_outdated_data()
+    profile_records = db_get_records(PerformanceProfile, system_id=system_id)
+    history_records = db_get_records(PerformanceProfileHistory, system_id=system_id)
+    assert profile_records.count() == (total_profile_records_before - 1)
+    assert history_records.count() == (total_history_records_before - 1)
+
+
+def test_gc_method_when_no_outdated_data(
+        garbage_collector,
+        db_setup,
+        db_create_system,
+        db_create_performance_profile,
+        db_create_performance_profile_history):
+    system_id = 1
+    profile_records = db_get_records(PerformanceProfile, system_id=system_id)
+    historical_profile_records = db_get_records(
+        PerformanceProfileHistory, system_id=system_id)
+    assert profile_records.count() == historical_profile_records.count() == 1
+    garbage_collector.remove_outdated_data()
+    profile_records = db_get_records(PerformanceProfile, system_id=system_id)
+    historical_profile_records = db_get_records(
+        PerformanceProfileHistory, system_id=system_id)
+    assert profile_records.count() == historical_profile_records.count() == 1

--- a/tests/test_insights_engine_result_consumer.py
+++ b/tests/test_insights_engine_result_consumer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from ros.lib.app import app
 from ros.lib.models import db, PerformanceProfile
 from ros.processor.insights_engine_result_consumer import InsightsEngineResultConsumer, SYSTEM_STATES
-from tests.helpers.db_helper import db_get_host
+from tests.helpers.db_helper import db_get_host, db_get_perf_profile
 
 
 @pytest.fixture(scope="function")
@@ -138,9 +138,10 @@ def test_process_report_optimized(engine_result_message, engine_consumer, db_set
     _performance_record = copy.copy(performance_record)
     engine_consumer.process_report(host, ros_reports, system_metadata, performance_record)
     system_record = db_get_host(host['id'])
+    profile_record = db_get_perf_profile(system_record.id)
     assert str(system_record.inventory_id) == host['id']
     with app.app_context():
-        assert system_record.rule_hit_details == ros_reports
+        assert profile_record.rule_hit_details == ros_reports
         assert system_record.instance_type == _performance_record['instance_type']
         assert system_record.region == _performance_record['region']
         assert system_record.state == SYSTEM_STATES['OPTIMIZED']


### PR DESCRIPTION
- [x] DB schema change
- [x] Population & fixing existing data as per new schema in performance_profile as well as performance_profile_history tables
- [x] Fixed existing model and APIs.  ([RHIROS-575](https://issues.redhat.com/browse/RHIROS-575)) 
- [x] Populate time information along with date for report_date column ([RHIROS-601](https://issues.redhat.com/browse/RHIROS-601))
- [x] Pulled @r14chandra's commit related consumers from PR https://github.com/RedHatInsights/ros-backend/pull/200 and made new changes to consumers files. These changes make sure performance_profile ONLY includes latest reported record per system ([RHIROS-574](https://issues.redhat.com/browse/RHIROS-574)) 
- [x] Fixed the broken tests 
- [x] Refactored existing queries to get last reported records from performance_profile table. Now, this table only includes latest record per system
- [x] Modified Garbage collector processor's implementation ([RHIROS-576](https://issues.redhat.com/browse/RHIROS-576))
- [x] Added tests related to GC change and historical record creation ([RHIROS-577](https://issues.redhat.com/browse/RHIROS-577))