### PR TITLE
RHIROS-689 Added monitoring process for Openshift props

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:
 	@echo "insights-upload-data       upload data to local ingress service for ROS processing"
 
 metadata={"branch_info": {"remote_branch": -1, "remote_leaf": -1}, "bios_uuid": "25d6ad97-60fa-4d3e-b2cc-4aa437c28f71", "ip_addresses": ["10.74.255.52", "2620:52:0:4af8:21a:4aff:fe00:a8a"], "fqdn": "vm255-52.gsslab.pnq2.redhat.com", "mac_addresses": ["00:1a:4a:00:0a:8a", "00:00:00:00:00:00"], "satellite_id": -1, "subscription_manager_id": "7846d4fa-6fcc-4b84-aa13-5f12e588ecca", "insights_id": "1d42f242-3828-4a00-8009-c67656c86a51", "machine_id": "25d6ad97-60fa-4d3e-b2cc-4aa437c28f71"}
-identity={"identity": {"account_number": "0000001","type": "User","user": {"username": "tuser@redhat.com","email": "tuser@redhat.com","first_name": "test","last_name": "user","is_active": true,"is_org_admin": false, "is_internal": true, "locale": "en_US"},"internal": { "org_id": "000001"}}}
+identity={"identity": {"account_number": "0000001", "auth_type": "basic-auth", "type": "User","user": {"username": "tuser@redhat.com","email": "tuser@redhat.com","first_name": "test","last_name": "user","is_active": true,"is_org_admin": false, "is_internal": true, "locale": "en_US"},"internal": { "org_id": "000001"}}}
 b64_identity=$(shell echo '${identity}' | base64 -w 0 -)
 
 insights-upload-data:

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -71,6 +71,26 @@ objects:
           limits:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 3
         env:
           - name: CLOWDER_ENABLED
             value: ${CLOWDER_ENABLED}

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -143,7 +143,6 @@ def insert_performance_profiles(session, system_id, fields):
         session.flush()
 
 
-
 def count_per_state(queryset, custom_filters: dict):
     return queryset.filter_by(**custom_filters).count() if queryset else 0
 
@@ -153,6 +152,7 @@ def calculate_percentage(numerator, denominator):
         return round((numerator / denominator) * 100, 2)
     else:
         return 0
+
 
 class MonitoringHandler(BaseHTTPRequestHandler):
     def do_GET(self):

--- a/ros/processor/main.py
+++ b/ros/processor/main.py
@@ -1,3 +1,5 @@
+from http.server import HTTPServer
+from ros.lib.utils import PROCESSOR_INSTANCES, MonitoringHandler
 from ros.lib.cw_logging import commence_cw_log_streaming
 from ros.processor.inventory_events_consumer import InventoryEventsConsumer
 from ros.processor.insights_engine_result_consumer import InsightsEngineResultConsumer
@@ -9,17 +11,28 @@ from ros.lib.config import METRICS_PORT
 
 def process_engine_results():
     processor = InsightsEngineResultConsumer()
+    processor.processor_name = 'process-engine-results'
+    PROCESSOR_INSTANCES.append(processor)
     processor.run()
 
 
 def events_processor():
     processor = InventoryEventsConsumer()
+    processor.processor_name = 'events-processor'
+    PROCESSOR_INSTANCES.append(processor)
     processor.run()
 
 
 def garbage_collector():
     collector = GarbageCollector()
+    collector.processor_name = 'garbage-collector'
+    PROCESSOR_INSTANCES.append(collector)
     collector.run()
+
+
+def thread_monitor():
+    server = HTTPServer(('', 8000), MonitoringHandler)
+    server.serve_forever()
 
 
 if __name__ == "__main__":
@@ -28,9 +41,11 @@ if __name__ == "__main__":
     engine_results = threading.Thread(name='process-engine-results', target=process_engine_results)
     events = threading.Thread(name='events-processor', target=events_processor)
     collector = threading.Thread(name='garbage-collector', target=garbage_collector)
+    threadmonitor = threading.Thread(name='thread-monitor', target=thread_monitor)
     events.start()
     engine_results.start()
     collector.start()
+    threadmonitor.start()
     start_http_server(int(METRICS_PORT))
     # Wait for threads to finish
     events.join()


### PR DESCRIPTION
In this PR we are giving each processor a name(processor_name) and adding its reference to PROCESSOR_INSTANCES array. Also we are giving names to each thread where [thread_name](https://github.com/RedHatInsights/ros-backend/pull/220/files#diff-6f48879fb5d9b6c7702c5db83686f993f3fc502e881d30167dd873207967c756L28) is equal to [processor_name](https://github.com/RedHatInsights/ros-backend/pull/220/files#diff-6f48879fb5d9b6c7702c5db83686f993f3fc502e881d30167dd873207967c756R14).
Idea is to simple get the names of all the [running thread](https://github.com/RedHatInsights/ros-backend/pull/220/files#diff-73b796983793ca68d788f97a84b00ef19df5157d5fee7ee854c47ed1133d45f1R160) and check if all PROCESSOR_INSTANCES name is present in list of running thread. if any of the thread is missing/dead we send the 500 response code. 