### PR TITLE
RHIROS-644 - modify log messages from processors

### DIFF
--- a/ros/processor/insights_engine_result_consumer.py
+++ b/ros/processor/insights_engine_result_consumer.py
@@ -192,5 +192,5 @@ class InsightsEngineResultConsumer:
                 processor_requests_failures.labels(
                     reporter=self.reporter, account_number=host['account']
                 ).inc()
-                LOG.error("%s - Unable to add host %s to DB belonging to account: %s - %s",
+                LOG.error("%s - Unable to add system %s to DB belonging to account: %s - %s",
                           self.prefix, host['id'], host['account'], err)

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -101,8 +101,8 @@ class InventoryEventsConsumer:
         host_id = msg['id']
         insights_id = msg['insights_id']
         with app.app_context():
-            LOG.info(
-                '%s - Deleting performance profile records with insights_id %s',
+            LOG.debug(
+                '%s - Received a message for system with insights_id %s',
                 self.prefix,
                 insights_id
             )
@@ -113,7 +113,7 @@ class InventoryEventsConsumer:
                     reporter=self.reporter, account_number=msg['account']
                 ).inc()
                 LOG.info(
-                    '%s - Deleted host with inventory id: %s',
+                    '%s - Deleted system with inventory id: %s',
                     self.prefix,
                     host_id
                 )
@@ -126,7 +126,7 @@ class InventoryEventsConsumer:
                 and msg['type'] == 'updated'
         ) or 'is_ros' in msg['platform_metadata']:
             LOG.info(
-                '%s - Processing a message for host(%s) belonging to account %s',
+                '%s - Processing a message for system(%s) belonging to account %s',
                 self.prefix, msg['host']['id'], msg['host']['account']
             )
             self.process_system_details(msg)
@@ -165,5 +165,5 @@ class InventoryEventsConsumer:
                 processor_requests_failures.labels(
                     reporter=self.reporter, account_number=host['account']
                 ).inc()
-                LOG.error("%s - Unable to add host %s to DB belonging to account: %s - %s",
+                LOG.error("%s - Unable to add system %s to DB belonging to account: %s - %s",
                           self.prefix, host['fqdn'], host['account'], err)

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -108,7 +108,7 @@ class InventoryEventsConsumer:
             )
             rows_deleted = db.session.query(System.id).filter(System.inventory_id == host_id).delete()
             db.session.commit()
-            if rows_deleted > 0:
+            if rows_deleted == 1:
                 processor_requests_success.labels(
                     reporter=self.reporter, account_number=msg['account']
                 ).inc()


### PR DESCRIPTION

- [x]  Unnecessary ROS inventory processor is printing log statements while receiving delete events for systems. In actual very few of them get processed by ROS processor. Modifying log level from info to debug.
- [x]  Renamed to host to system in log messages for consistency.