### PR TITLE
added ros api path in clowdapp.yaml

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -19,6 +19,7 @@ objects:
       webServices:
         public:
           enabled: true
+          apiPath: ros
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         minReplicas: 1


### PR DESCRIPTION
### Description:

added ros api path in clowdapp.yaml.
As we had not set the api path in clowdapp.yaml, in EE it was using app name and due to this the frontend was not working in the EE. This PR fixes the issue. 

References:

https://ansible.slack.com/archives/C023VGW21NU/p1656075925640389?thread_ts=1655715454.841739&cid=C023VGW21NU

https://coreos.slack.com/archives/C022YV4E0NA/p1656071317819399

![image](https://user-images.githubusercontent.com/5928530/175548617-d7720f5e-3858-465f-b965-552f517d35ff.png)


