### PR TITLE
RHIROS-731 Added API caching for ROS

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,7 @@ watchtower = ">=1.0.0"
 boto3 = ">=1.16.13"
 botocore = ">=1.19.13"
 markupsafe = "==2.0.1"  # Necessary locking, issue: https://github.com/aws/aws-sam-cli/issues/3661
+flask-caching = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f97e3056db018892fc4a4c10566919037fff842eff7400f948c035de1002d8d"
+            "sha256": "40f7ff734ceeeebaac162e71f5c6cb3bc6f40d22cfde1797eae2096b9f30c1bf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,30 +49,35 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:af12023bb8f3059bb72697bcf9be860c492760c8201ec09246bd0b04cea88573",
-                "sha256:efce6dcf0b708cf609b2583f0134b1896f4e76c8b1e25702d50c81719a213664"
+                "sha256:52f16ba56e47f8393cae2d09bbfca26083958adde08027c46265bc9012f6d4bc",
+                "sha256:edcfd95c2fd8335e2228ca7876e8e3967c506e1c6b42371fb557606ce7233f5a"
             ],
             "index": "pypi",
-            "version": "==1.24.28"
+            "version": "==1.24.43"
         },
         "botocore": {
             "hashes": [
-                "sha256:b00da6290d8d42c6c3048b045d6537421e8b83e03b4f24bb44c5ea9f37ab6258",
-                "sha256:cd4dff88419c7b6865f91551db3eb526283ebc56dc99f1d9b7adb5aa080674f8"
+                "sha256:3cfe585e90069e8e7b6ec10855976d974ec13a53bbf9b1a0f77193804be7cb17",
+                "sha256:ade148d0e29f633f429ea6c7ea215e173c64e8b155e574950892aa4eade969d0"
             ],
             "index": "pypi",
-            "version": "==1.27.28"
+            "version": "==1.27.43"
         },
         "cachecontrol": {
-            "extras": [
-                "filecache"
-            ],
             "hashes": [
                 "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b",
                 "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.12.11"
+        },
+        "cachelib": {
+            "hashes": [
+                "sha256:38222cc7c1b79a23606de5c2607f4925779e37cdcea1c2ad21b8bae94b5425a5",
+                "sha256:811ceeb1209d2fe51cd2b62810bd1eccf70feba5c52641532498be5c675493b3"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.9.0"
         },
         "certifi": {
             "hashes": [
@@ -154,6 +159,14 @@
             "index": "pypi",
             "version": "==1.1.4"
         },
+        "flask-caching": {
+            "hashes": [
+                "sha256:10df200a03f032af60077befe41779dd94898b67c82040d34e87210b71ba2638",
+                "sha256:703df847cbe904d8ddffd5f5fb320e236a31cb7bebac4a93d6b1701dd16dbf37"
+            ],
+            "index": "pypi",
+            "version": "==2.0.1"
+        },
         "flask-cors": {
             "hashes": [
                 "sha256:74efc975af1194fc7891ff5cd85b0f7478be4f7f59fe158102e91abb72bb4438",
@@ -219,19 +232,19 @@
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751",
-                "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"
+                "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681",
+                "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==5.8.0"
+            "version": "==5.9.0"
         },
         "insights-core": {
             "hashes": [
-                "sha256:8b5209a734483f705e5124c4c3a8d2637be845d33d071be8b4c2d8dee7c71550",
-                "sha256:df4d036978ecedfc21e934607547679e971eddd7b3ffc4e585394d57fde7fad9"
+                "sha256:87e01fa4622113374a12ed6074196ea989f909f9244b792538317318f02b3004",
+                "sha256:dc50a559d9dfb9ef5043b4009d867ce5ef30f1468a980d01f0fb148c59559924"
             ],
             "index": "pypi",
-            "version": "==3.0.283"
+            "version": "==3.0.286"
         },
         "itsdangerous": {
             "hashes": [
@@ -490,7 +503,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "pytz": {
@@ -565,18 +578,18 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-                "sha256:db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65"
+                "sha256:273b6847ae61f7829c1affcdd9a32f67aa65233be508f4fbaab866c5faa4e408",
+                "sha256:d5340d16943a0f67057329db59b564e938bb3736c6e50ae16ea84d5e5d9ba6d0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.1.0"
+            "version": "==63.3.0"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "sqlalchemy": {
@@ -621,11 +634,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
-                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
+                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.10"
+            "version": "==1.26.11"
         },
         "watchtower": {
             "hashes": [
@@ -725,11 +738,11 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
         },
         "coverage": {
             "extras": [
@@ -783,11 +796,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
-                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+                "sha256:93aa565ae2f0316b95bb57a354f2b2d55ee8508e1fe1cb13b77b9c195b4a2537",
+                "sha256:b27fd7faa8d90aaae763664a489012292990388e5d3604f383b290caefbbc922"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==5.0.3"
         },
         "greenlet": {
             "hashes": [
@@ -847,7 +860,7 @@
                 "sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c",
                 "sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b"
             ],
-            "markers": "python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "markers": "python_version >= '3' and (platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32'))))))",
             "version": "==1.1.2"
         },
         "iniconfig": {
@@ -859,10 +872,11 @@
         },
         "mccabe": {
             "hashes": [
-                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
             ],
-            "version": "==0.6.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
         },
         "packaging": {
             "hashes": [
@@ -890,19 +904,19 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
-                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+                "sha256:289cdc0969d589d90752582bef6dff57c5fbc6949ee8b013ad6d6449a8ae9437",
+                "sha256:beaba44501f89d785be791c9462553f06958a221d166c64e1f107320f839acc2"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.8.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.9.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
-                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+                "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2",
+                "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.0"
         },
         "pyparsing": {
             "hashes": [

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -102,6 +102,7 @@ objects:
     database:
       name: ros
       version: 12
+    inMemoryDb: true
     kafkaTopics:
       - topicName: platform.inventory.events
         partitions: 1

--- a/ros/api/main.py
+++ b/ros/api/main.py
@@ -1,12 +1,13 @@
 from flask_restful import Api
 from flask_cors import CORS
 from ros.api.routes import initialize_routes
-from ros.lib.app import app, metrics
+from ros.lib.app import app, metrics, cache
 from ros.lib.cw_logging import commence_cw_log_streaming
 
 CORS(app)
 api = Api(app)
 initialize_routes(api)
+cache.init_app(app)
 metrics.init_app(app, api)
 
 if __name__ == "__main__":

--- a/ros/api/v1/call_to_action.py
+++ b/ros/api/v1/call_to_action.py
@@ -4,54 +4,63 @@ from ros.lib.utils import (
     org_id_from_identity_header, system_ids_by_org_id)
 from ros.lib.models import (
     PerformanceProfile, db)
+from ros.lib.app import cache
 
 
 class CallToActionApi(Resource):
     def get(self):
         org_id = org_id_from_identity_header(request)
-        system_query = system_ids_by_org_id(org_id).filter(PerformanceProfile.number_of_recommendations > 0)
-        query = (
-            db.session.query(PerformanceProfile.system_id)
-            .filter(PerformanceProfile.system_id.in_(system_query.subquery()))
-        )
-        total_system_count = query.count()
-
-        configTryLearn_Object = {
-            "try": [{
-                "shape": {
-                    "title": "Install and begin using Resource optimization service.",
-                    "description": "Optimize your spending in public cloud.",
-                    "link": {
-                        "title": "Get started",
-                        "href": "/insights/ros?with_suggestions=true",
-                    },
-                },
-            }]
-        }
-        if total_system_count == 0:
-            return {
-               "configTryLearn": configTryLearn_Object
-            }
+        cache_key = "call_to_action_"+org_id
+        if res := cache.get(cache_key):
+            return res
         else:
-            if total_system_count > 1:
-                suffix = 'systems'
-            else:
-                suffix = 'system'
-            return {
-                "recommendations": {
-                    "redhatInsights": [
-                        {
-                            "id": "ros-1",
-                            "description": "Resource optimization recommends to assess and monitor"
-                            + " cloud usage and optimization on these systems",
-                            "icon": "cog",
-                            "action": {
-                                "title": f"View {total_system_count} {suffix}"
-                                + " with suggestions",
-                                "href": "/insights/ros?with_suggestions=true"
-                            }
-                        }
-                    ]
-                },
-                "configTryLearn": configTryLearn_Object
+            system_query = system_ids_by_org_id(org_id).filter(PerformanceProfile.number_of_recommendations > 0)
+            query = (
+                db.session.query(PerformanceProfile.system_id)
+                .filter(PerformanceProfile.system_id.in_(system_query.subquery()))
+            )
+            total_system_count = query.count()
+
+            configTryLearn_Object = {
+                "try": [{
+                    "shape": {
+                        "title": "Install and begin using Resource optimization service.",
+                        "description": "Optimize your spending in public cloud.",
+                        "link": {
+                            "title": "Get started",
+                            "href": "/insights/ros?with_suggestions=true",
+                        },
+                    },
+                }]
             }
+            if total_system_count == 0:
+                result = {
+                    "configTryLearn": configTryLearn_Object
+                }
+                cache.set(cache_key, result)
+                return result
+            else:
+                if total_system_count > 1:
+                    suffix = 'systems'
+                else:
+                    suffix = 'system'
+                result = {
+                    "recommendations": {
+                        "redhatInsights": [
+                            {
+                                "id": "ros-1",
+                                "description": "Resource optimization recommends to assess and monitor"
+                                + " cloud usage and optimization on these systems",
+                                "icon": "cog",
+                                "action": {
+                                    "title": f"View {total_system_count} {suffix}"
+                                    + " with suggestions",
+                                    "href": "/insights/ros?with_suggestions=true"
+                                }
+                            }
+                        ]
+                    },
+                    "configTryLearn": configTryLearn_Object
+                }
+                cache.set(cache_key, result)
+                return result

--- a/ros/api/v1/call_to_action.py
+++ b/ros/api/v1/call_to_action.py
@@ -13,54 +13,54 @@ class CallToActionApi(Resource):
         cache_key = "call_to_action_"+org_id
         if res := cache.get(cache_key):
             return res
-        else:
-            system_query = system_ids_by_org_id(org_id).filter(PerformanceProfile.number_of_recommendations > 0)
-            query = (
-                db.session.query(PerformanceProfile.system_id)
-                .filter(PerformanceProfile.system_id.in_(system_query.subquery()))
-            )
-            total_system_count = query.count()
 
-            configTryLearn_Object = {
-                "try": [{
-                    "shape": {
-                        "title": "Install and begin using Resource optimization service.",
-                        "description": "Optimize your spending in public cloud.",
-                        "link": {
-                            "title": "Get started",
-                            "href": "/insights/ros?with_suggestions=true",
-                        },
+        system_query = system_ids_by_org_id(org_id).filter(PerformanceProfile.number_of_recommendations > 0)
+        query = (
+            db.session.query(PerformanceProfile.system_id)
+            .filter(PerformanceProfile.system_id.in_(system_query.subquery()))
+        )
+        total_system_count = query.count()
+
+        configTryLearn_Object = {
+            "try": [{
+                "shape": {
+                    "title": "Install and begin using Resource optimization service.",
+                    "description": "Optimize your spending in public cloud.",
+                    "link": {
+                        "title": "Get started",
+                        "href": "/insights/ros?with_suggestions=true",
                     },
-                }]
+                },
+            }]
+        }
+        if total_system_count == 0:
+            result = {
+                "configTryLearn": configTryLearn_Object
             }
-            if total_system_count == 0:
-                result = {
-                    "configTryLearn": configTryLearn_Object
-                }
-                cache.set(cache_key, result)
-                return result
-            else:
-                if total_system_count > 1:
-                    suffix = 'systems'
-                else:
-                    suffix = 'system'
-                result = {
-                    "recommendations": {
-                        "redhatInsights": [
-                            {
-                                "id": "ros-1",
-                                "description": "Resource optimization recommends to assess and monitor"
-                                + " cloud usage and optimization on these systems",
-                                "icon": "cog",
-                                "action": {
-                                    "title": f"View {total_system_count} {suffix}"
-                                    + " with suggestions",
-                                    "href": "/insights/ros?with_suggestions=true"
-                                }
-                            }
-                        ]
-                    },
-                    "configTryLearn": configTryLearn_Object
-                }
-                cache.set(cache_key, result)
-                return result
+            cache.set(cache_key, result)
+            return result
+
+        if total_system_count > 1:
+            suffix = 'systems'
+        else:
+            suffix = 'system'
+        result = {
+            "recommendations": {
+                "redhatInsights": [
+                    {
+                        "id": "ros-1",
+                        "description": "Resource optimization recommends to assess and monitor"
+                        + " cloud usage and optimization on these systems",
+                        "icon": "cog",
+                        "action": {
+                            "title": f"View {total_system_count} {suffix}"
+                            + " with suggestions",
+                            "href": "/insights/ros?with_suggestions=true"
+                        }
+                    }
+                ]
+            },
+            "configTryLearn": configTryLearn_Object
+        }
+        cache.set(cache_key, result)
+        return result

--- a/ros/lib/app.py
+++ b/ros/lib/app.py
@@ -3,8 +3,9 @@ from .models import db
 from .config import DB_URI
 from flask import request
 from .rbac_interface import ensure_has_permission
-from .config import get_logger
+from .config import get_logger, REDIS_URL
 from prometheus_flask_exporter import RESTfulPrometheusMetrics
+from flask_caching import Cache
 
 # Since we're using flask_sqlalchemy, we must create the flask app in both processor and web api
 app = Flask(__name__)
@@ -12,6 +13,7 @@ app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = DB_URI
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 metrics = RESTfulPrometheusMetrics.for_app_factory(defaults_prefix='ros')
+cache = Cache(config={'CACHE_TYPE': 'RedisCache', 'CACHE_REDIS_URL': REDIS_URL, 'CACHE_DEFAULT_TIMEOUT': 300})
 db.init_app(app)
 
 

--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -47,6 +47,10 @@ if CLOWDER_ENABLED:
     DB_PASSWORD = LoadedConfig.database.password
     DB_HOST = LoadedConfig.database.hostname
     DB_PORT = LoadedConfig.database.port
+    REDIS_USERNAME = LoadedConfig.inMemoryDb.username
+    REDIS_PASSWORD = LoadedConfig.inMemoryDb.password
+    REDIS_HOST = LoadedConfig.inMemoryDb.hostname
+    REDIS_PORT = LoadedConfig.inMemoryDb.port
     METRICS_PORT = LoadedConfig.metricsPort
     KAFKA_BROKER = LoadedConfig.kafka.brokers[0]
     INSIGHTS_KAFKA_ADDRESS = KAFKA_BROKER.hostname + ":" + str(KAFKA_BROKER.port)
@@ -71,6 +75,10 @@ else:
     DB_PASSWORD = os.getenv("ROS_DB_PASS", "postgres")
     DB_HOST = os.getenv("ROS_DB_HOST", "localhost")
     DB_PORT = os.getenv("ROS_DB_PORT", "15432")
+    REDIS_USERNAME = os.getenv("REDIS_USERNAME", default="")
+    REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", default="")
+    REDIS_HOST = os.getenv("REDIS_HOST", default="localhost")
+    REDIS_PORT = os.getenv("REDIS_PORT", default=6379)
     INSIGHTS_KAFKA_HOST = os.getenv("INSIGHTS_KAFKA_HOST", "localhost")
     INSIGHTS_KAFKA_PORT = os.getenv("INSIGHTS_KAFKA_PORT", "9092")
     INSIGHTS_KAFKA_ADDRESS = f"{INSIGHTS_KAFKA_HOST}:{INSIGHTS_KAFKA_PORT}"
@@ -91,6 +99,8 @@ else:
 
 DB_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}"\
                 f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+REDIS_AUTH = f"{REDIS_USERNAME or ''}:{REDIS_PASSWORD}@" if REDIS_PASSWORD else ""
+REDIS_URL = f"redis://{REDIS_AUTH}{REDIS_HOST}:{REDIS_PORT}"
 GROUP_ID = os.getenv('GROUP_ID', 'resource-optimization')
 PATH_PREFIX = os.getenv("PATH_PREFIX", "/api/")
 APP_NAME = os.getenv("APP_NAME", "ros")

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,5 +1,9 @@
 version: "3.8"
 services:
+  redis:
+    image: quay.io/cloudservices/redis-ephemeral:6
+    ports:
+      - "6379:6379"
   zookeeper:
     image: confluentinc/cp-zookeeper
     environment:


### PR DESCRIPTION
We are getting many hits on call_to_action API, reason - call_to_action API gets called from console dashboard so for every user coming to consoledot will hit call_to_action API though he/she is not a ROS user. To reduce DB connections/queries adding redis to cache the call_to_action API with TTL of 5 mins.
**Note - Do not merge this PR before merging app-interface MR linked in JIRA ticket.** 