### PR TITLE
Refs #RHIROS-731 - Increase SQLAlchemy DB pool size

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -59,6 +59,10 @@ objects:
             value: ${CLOWDER_ENABLED}
           - name: ENABLE_RBAC
             value: "${ENABLE_RBAC}"
+          - name: DB_POOL_SIZE
+            value: ${DB_POOL_SIZE}
+          - name: DB_MAX_OVERFLOW
+            value: ${DB_MAX_OVERFLOW}
     - name: processor
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
@@ -99,6 +103,10 @@ objects:
             value: ${GARBAGE_COLLECTION_INTERVAL}
           - name: DAYS_UNTIL_STALE
             value: ${DAYS_UNTIL_STALE}
+          - name: DB_POOL_SIZE
+            value: ${DB_POOL_SIZE}
+          - name: DB_MAX_OVERFLOW
+            value: ${DB_MAX_OVERFLOW}
     database:
       name: ros
       version: 12
@@ -202,3 +210,7 @@ parameters:
   value: "localhost"
 - name: POPULATOR_LOG_FORMAT
   value: cloudwatch 
+- name: DB_POOL_SIZE
+  value: "20"
+- name: DB_MAX_OVERFLOW
+  value: "50"

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -213,4 +213,4 @@ parameters:
 - name: DB_POOL_SIZE
   value: "20"
 - name: DB_MAX_OVERFLOW
-  value: "50"
+  value: "20"

--- a/ros/lib/app.py
+++ b/ros/lib/app.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from .models import db
-from .config import DB_URI
+from .config import DB_URI, DB_POOL_SIZE, DB_MAX_OVERFLOW
 from flask import request
 from .rbac_interface import ensure_has_permission
 from .config import get_logger, REDIS_URL
@@ -11,6 +11,10 @@ from flask_caching import Cache
 app = Flask(__name__)
 # Initalize database connection
 app.config['SQLALCHEMY_DATABASE_URI'] = DB_URI
+app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+    'pool_size': DB_POOL_SIZE,
+    'max_overflow': DB_MAX_OVERFLOW
+}
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 metrics = RESTfulPrometheusMetrics.for_app_factory(defaults_prefix='ros')
 cache = Cache(config={'CACHE_TYPE': 'RedisCache', 'CACHE_REDIS_URL': REDIS_URL, 'CACHE_DEFAULT_TIMEOUT': 300})

--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -99,6 +99,8 @@ else:
 
 DB_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}"\
                 f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", '5'))
+DB_MAX_OVERFLOW = int(os.getenv("DB_MAX_OVERFLOW", '10'))
 REDIS_AUTH = f"{REDIS_USERNAME or ''}:{REDIS_PASSWORD}@" if REDIS_PASSWORD else ""
 REDIS_URL = f"redis://{REDIS_AUTH}{REDIS_HOST}:{REDIS_PORT}"
 GROUP_ID = os.getenv('GROUP_ID', 'resource-optimization')


### PR DESCRIPTION
Seems like API caching has not solved the QueuePool size limit issue. We will need to increase the `SQLALCHEMY_POOL_SIZE`. 

I have checked other services like [vulnerability-engine](https://github.com/RedHatInsights/vulnerability-engine/blob/d31b67a7223ff69ee3c4220e79304268f2363c62/deploy/clowdapp.yaml#L914), [payload-tracker](https://github.com/RedHatInsights/payload-tracker/blob/827f66ce3c2810abcfc3acfa9cee1021141827ad/deploy/deploy.yml#L259) etc they are having higher pool size.