### PR TITLE
Update References to 3Scale Dev Deployment

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -204,7 +204,7 @@ parameters:
 - description: Host for the EAN to OrgId translator.
   name: TENANT_TRANSLATOR_HOST
   required: true
-  value: 'apicast.3scale-dev.svc.cluster.local'
+  value: 'gateway.3scale-dev.svc.cluster.local'
 - description: Port for the EAN to OrgId translator.
   name: TENANT_TRANSLATOR_PORT
   value: '8892'


### PR DESCRIPTION
#### Jira Epic: https://issues.redhat.com/browse/RHCLOUD-20162
#### Jira Ticket: https://issues.redhat.com/browse/RHCLOUD-20960
----

- Updating references from the old 3scale dev deployment `apicast.3scale-dev.svc.cluster.local` to the new 3scale dev deployment `gateway.3scale-dev.svc.cluster.local`
- The reason for this change is the Infrastructure Team has stood up a new 3scale (Gateway) Deployment to support service serving certificates. Currently, both the old and new deployments are running in parallel so we can aid workstreams in the change over. 