### PR TITLE
Fixes #RHIROS-837 - fix account info in events

### DIFF
--- a/ros/processor/event_producer.py
+++ b/ros/processor/event_producer.py
@@ -19,7 +19,7 @@ def new_suggestion_event(host, platform_metadata, previous_state, current_state,
         "application": "resource-optimization",
         "event_type": "new-suggestion",
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "account_id": host.get("account_id") or "",
+        "account_id": host.get("account") or "",
         "org_id": org_id,
         "context": {
             "event_name": "New suggestion",


### PR DESCRIPTION
Refer sample kafka messages:
- https://github.com/RedHatInsights/ros-backend/blob/main/tests/data_files/insights-engine-result-idle.json#L36
- https://github.com/RedHatInsights/ros-backend/blob/main/tests/data_files/events-message.json#L1126

Key should be `account` instead of `account_id`.