### PR TITLE
RHIROS-892 update os filtering logic

### DIFF
--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -189,12 +189,15 @@ class HostsApi(Resource):
                 # FIXME: remove `if` block after getting OS values as numeric from frontend
                 if "RHEL" in os:
                     os = os.split(" ")[1]
-                os_object = {"name": "RHEL"}
-                if len(os) == 1:
-                    os += ".0"
-                os_object["major"] = int(os.split(".")[0])
-                os_object["minor"] = int(os.split(".")[1])
-                modified_operating_systems.append(os_object)
+                if os.replace('.', '', 1).isdigit():
+                    os_object = {"name": "RHEL"}
+                    if len(os) == 1:
+                        os += ".0"
+                    os_object["major"] = int(os.split(".")[0])
+                    os_object["minor"] = int(os.split(".")[1])
+                    modified_operating_systems.append(os_object)
+                else:
+                    abort(400, message='Not a valid RHEL version')
             filters.append(System.operating_system.in_(modified_operating_systems))
         return filters
 

--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -38,26 +38,6 @@ LOG = logging.getLogger(__name__)
 SYSTEM_STATES_EXCEPT_EMPTY = [
     "Oversized", "Undersized", "Idling", "Under pressure", "Storage rightsizing", "Optimized", "Waiting for data"
 ]
-OS_VERSIONS = {
-    '7.0': {"name": "RHEL", "major": 7, "minor": 0},
-    '7.1': {"name": "RHEL", "major": 7, "minor": 1},
-    '7.2': {"name": "RHEL", "major": 7, "minor": 2},
-    '7.3': {"name": "RHEL", "major": 7, "minor": 3},
-    '7.4': {"name": "RHEL", "major": 7, "minor": 4},
-    '7.5': {"name": "RHEL", "major": 7, "minor": 5},
-    '7.6': {"name": "RHEL", "major": 7, "minor": 6},
-    '7.7': {"name": "RHEL", "major": 7, "minor": 7},
-    '7.8': {"name": "RHEL", "major": 7, "minor": 8},
-    '7.9': {"name": "RHEL", "major": 7, "minor": 9},
-    '8.0': {"name": "RHEL", "major": 8, "minor": 0},
-    '8.1': {"name": "RHEL", "major": 8, "minor": 1},
-    '8.2': {"name": "RHEL", "major": 8, "minor": 2},
-    '8.3': {"name": "RHEL", "major": 8, "minor": 3},
-    '8.4': {"name": "RHEL", "major": 8, "minor": 4},
-    '8.5': {"name": "RHEL", "major": 8, "minor": 5},
-    '8.6': {"name": "RHEL", "major": 8, "minor": 6},
-    '9.0': {"name": "RHEL", "major": 9, "minor": 0},
-}
 
 SYSTEM_COLUMNS = [
     'inventory_id',
@@ -206,10 +186,10 @@ class HostsApi(Resource):
         if operating_systems := request.args.getlist('os'):
             modified_operating_systems = []
             for os in operating_systems:
-                os = os.split(" ")[1]
-                if os not in OS_VERSIONS.keys():
-                    abort(400, message='Not a valid RHEL version')
-                modified_operating_systems.append(OS_VERSIONS[os])
+                os_object = {"name": "RHEL"}
+                os_object["major"] = int(os.split(".")[0])
+                os_object["minor"] = int(os.split(".")[1])
+                modified_operating_systems.append(os_object)
             filters.append(System.operating_system.in_(modified_operating_systems))
         return filters
 

--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -187,6 +187,8 @@ class HostsApi(Resource):
             modified_operating_systems = []
             for os in operating_systems:
                 os_object = {"name": "RHEL"}
+                if len(os) == 1:
+                    os += ".0"
                 os_object["major"] = int(os.split(".")[0])
                 os_object["minor"] = int(os.split(".")[1])
                 modified_operating_systems.append(os_object)

--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -186,6 +186,9 @@ class HostsApi(Resource):
         if operating_systems := request.args.getlist('os'):
             modified_operating_systems = []
             for os in operating_systems:
+                # FIXME: remove `if` block after getting OS values as numeric from frontend
+                if "RHEL" in os:
+                    os = os.split(" ")[1]
                 os_object = {"name": "RHEL"}
                 if len(os) == 1:
                     os += ".0"

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -863,31 +863,11 @@
                 "name": "os",
                 "in": "query",
                 "required": false,
-                "description": "Filter system with the given os version",
+                "description": "Filter system with the given RHEL OS version. Eg, 8.4",
                 "schema": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "enum": [
-                            "RHEL 7.0",
-                            "RHEL 7.1",
-                            "RHEL 7.2",
-                            "RHEL 7.3",
-                            "RHEL 7.4",
-                            "RHEL 7.5",
-                            "RHEL 7.6",
-                            "RHEL 7.7",
-                            "RHEL 7.8",
-                            "RHEL 7.9",
-                            "RHEL 8.0",
-                            "RHEL 8.1",
-                            "RHEL 8.2",
-                            "RHEL 8.3",
-                            "RHEL 8.4",
-                            "RHEL 8.5",
-                            "RHEL 8.6",
-                            "RHEL 9.0"
-                        ]
+                        "type": "string"
                     }
                 }
             }

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -124,7 +124,7 @@ def test_system_no_os(auth_token, db_setup, db_create_account, db_create_system,
 def test_system_os_filter(auth_token, db_setup, db_create_account, db_create_system, db_create_performance_profile):
     with app.test_client() as client:
         response = client.get(
-            '/api/ros/v1/systems?os=RHEL 8.4',
+            '/api/ros/v1/systems?os=8.4',
             headers={"x-rh-identity": auth_token}
         )
         assert response.status_code == 200


### PR DESCRIPTION
Removed hardcoded os versions.
Now, we're showing os versions in the os filter that are registered with a user account.

- If all child versions are selected then their parent version will be selected automatically.
- If a parent version is selected then all its child versions will be selected automatically.

API docs
![Screenshot from 2022-12-21 17-07-03](https://user-images.githubusercontent.com/61837065/208898798-6c444207-bca8-4fc9-bf5e-1d9853125d4f.png)

UI
![Screenshot from 2022-12-21 17-05-41](https://user-images.githubusercontent.com/61837065/208898847-50448c98-9391-4651-b765-231d538a9e15.png)



