### PR TITLE
RHIROS-928| Exclusion filter for RHEL 7 systems - psi-enabled-count

### DIFF
--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -4,7 +4,7 @@ from sqlalchemy.types import Float
 from ros.lib.constants import SubStates
 
 from datetime import datetime, timedelta, timezone
-from sqlalchemy import asc, desc, nullslast, nullsfirst, Integer
+from sqlalchemy import asc, desc, nullslast, nullsfirst
 from flask_restful import Resource, abort, fields, marshal_with
 
 from ros.lib.models import (
@@ -25,7 +25,7 @@ from ros.lib.utils import (
     count_per_state,
     calculate_percentage,
     org_id_from_identity_header,
-    highlights_instance_types,
+    highlights_instance_types, get_psi_count,
 )
 from ros.api.common.pagination import (
     limit_value,
@@ -515,12 +515,8 @@ class ExecutiveReportAPI(Resource):
             PerformanceProfile.report_date <= stale_date
         ).count()
 
-        non_psi_count = systems_with_performance_record_queryset.filter(
-            PerformanceProfile.operating_system['major'].astext.cast(Integer) != 7,
-            PerformanceProfile.psi_enabled == False  # noqa
-        ).count()
-
-        psi_enabled_count = systems_with_performance_record_queryset.filter_by(psi_enabled=True).count()
+        non_psi_count = get_psi_count(systems_with_performance_record_queryset, False)
+        psi_enabled_count = get_psi_count(systems_with_performance_record_queryset, True)
 
         response = {
             "systems_per_state": {

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -8,6 +8,8 @@ import base64
 import json
 from flask import jsonify, make_response
 from flask_restful import abort
+from sqlalchemy import Integer
+
 from ros.lib.models import (
     RhAccount,
     System,
@@ -188,6 +190,13 @@ class MonitoringHandler(BaseHTTPRequestHandler):
             return
         else:
             super().log_request(code, size)
+
+
+def get_psi_count(queryset: db.Model, bool_flag: bool) -> int:
+    return queryset.filter(
+        PerformanceProfile.operating_system['major'].astext.cast(Integer) != 7,
+        PerformanceProfile.psi_enabled == bool_flag
+    ).count()
 
 
 def generate_highlight_description(instance_type, cloud_provider):


### PR DESCRIPTION
### Changes:
1. Added RHEL 7 filter for psi-enabled-count