### PR TITLE
Fixes #RHIROS-786 - handle exception on invalid value for rating

### DIFF
--- a/ros/api/common/utils.py
+++ b/ros/api/common/utils.py
@@ -3,12 +3,13 @@ import logging
 from flask import request
 from flask_restful import abort
 from ros.lib.models import System, RatingChoicesEnum
-from ros.lib.utils import identity, user_data_from_identity
+from ros.lib.utils import identity, user_data_from_identity, is_valid_uuid
+
 
 LOG = logging.getLogger(__name__)
 
 
-def validate_rating_post_api(func):
+def validate_rating_data(func):
     """Validate POST rating request."""
     allowed_choices = [c.value for c in RatingChoicesEnum]
 
@@ -45,6 +46,9 @@ def validate_rating_post_api(func):
         return username
 
     def check_for_system(inventory_id):
+        if not is_valid_uuid(inventory_id):
+            abort(404, message='Invalid inventory_id, Id should be in form of UUID4')
+
         system = System.query.filter(
             System.inventory_id == inventory_id
         ).first()

--- a/ros/api/common/utils.py
+++ b/ros/api/common/utils.py
@@ -1,0 +1,79 @@
+import json
+import logging
+from flask import request
+from flask_restful import abort
+from ros.lib.models import System, RatingChoicesEnum
+from ros.lib.utils import identity, user_data_from_identity
+
+LOG = logging.getLogger(__name__)
+
+
+def validate_rating_post_api(func):
+    """Validate POST rating request."""
+    allowed_choices = [c.value for c in RatingChoicesEnum]
+
+    def error_msg(error_code, value):
+        errors = {
+            400: "is invalid value for rating.",
+            422: "is invalid choice of input for rating."
+        }
+        return (
+            f"'{value}' { errors.get(error_code, 'Invalid') }"
+            f" Possible values - { *allowed_choices, }"
+        )
+
+    def check_for_rating(data):
+        rating = None
+        try:
+            rating = int(data['rating'])
+        except ValueError:
+            abort(400, message=(error_msg(400, data['rating'])))
+
+        if rating not in allowed_choices:
+            abort(422, message=(error_msg(422, data['rating'])))
+
+        return rating
+
+    def check_for_user():
+        ident = identity(request)['identity']
+        user = user_data_from_identity(ident)
+        username = user['username'] if 'username' in user else None
+
+        if username is None:
+            abort(403, message="Username doesn't exist")
+
+        return username
+
+    def check_for_system(inventory_id):
+        system = System.query.filter(
+            System.inventory_id == inventory_id
+        ).first()
+
+        if system is None:
+            abort(404, message=f"System {inventory_id} doesn't exist.")
+
+        return system.id
+
+    def validate_request(*args, **kwargs):
+        username = check_for_user()
+        data = None
+        try:
+            data = json.loads(request.data)
+        except json.decoder.JSONDecodeError as err:
+            LOG.error('Decoding JSON has failed. %s', repr(err))
+            abort(400, message="Decoding JSON has failed.")
+        except TypeError as ex:
+            LOG.error('Invalid JSON format. %s', repr(ex))
+            abort(400, message="Invalid JSON format.")
+
+        inventory_id = data['inventory_id']
+        system_id = check_for_system(inventory_id)
+        rating = check_for_rating(data)
+        new_kwargs = {
+            'rating': rating, 'username': username,
+            'inventory_id': inventory_id, 'system_id': system_id
+        }
+        new_kwargs.update(kwargs)
+        return func(*args, **new_kwargs)
+
+    return validate_request

--- a/ros/api/v1/recommendation_ratings.py
+++ b/ros/api/v1/recommendation_ratings.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource, fields, marshal_with
 from ros.lib.models import RecommendationRating, db
-from ros.api.common.utils import validate_rating_post_api
+from ros.api.common.utils import validate_rating_data
 
 
 class RecommendationRatingsApi(Resource):
@@ -10,7 +10,7 @@ class RecommendationRatingsApi(Resource):
         'rating': fields.Integer
     }
 
-    @validate_rating_post_api
+    @validate_rating_data
     @marshal_with(rating_fields)
     def post(self, **kwargs):
         """

--- a/ros/api/v1/recommendation_ratings.py
+++ b/ros/api/v1/recommendation_ratings.py
@@ -5,20 +5,33 @@ from ros.lib.models import RecommendationRating, System, db, RatingChoicesEnum
 from ros.lib.utils import identity, user_data_from_identity
 
 
-class RecommendationRatingsApi(Resource):
+def validate_rating_post_api(func):
+    """Validate POST rating request."""
+    allowed_choices = [c.value for c in RatingChoicesEnum]
 
-    rating_fields = {
-        'inventory_id': fields.String,
-        'rating': fields.Integer
-    }
+    def error_msg(error_code, value):
+        errors = {
+            400: "is invalid value for rating.",
+            422: "is invalid choice of input for rating."
+        }
+        return (
+            f"'{value}' { errors.get(error_code, 'Invalid') }"
+            f"Possible values - { *allowed_choices, }"
+        )
 
-    @marshal_with(rating_fields)
-    def post(self):
-        """
-            Add or update a rating for a system, by system ID.
-            Return the new rating. Any previous rating for this rule by this
-            user is amended to the current value.
-        """
+    def check_for_rating(data):
+        rating = None
+        try:
+            rating = int(data['rating'])
+        except ValueError:
+            abort(400, message=(error_msg(400, data['rating'])))
+
+        if rating not in allowed_choices:
+            abort(422, message=(error_msg(422, data['rating'])))
+
+        return rating
+
+    def check_for_user():
         ident = identity(request)['identity']
         user = user_data_from_identity(ident)
         username = user['username'] if 'username' in user else None
@@ -26,24 +39,9 @@ class RecommendationRatingsApi(Resource):
         if username is None:
             abort(403, message="Username doesn't exist")
 
-        data = json.loads(request.data)
-        inventory_id = data['inventory_id']
-        allowed_choices = [c.value for c in RatingChoicesEnum]
+        return username
 
-        def invalid_value_msg(val):
-            return (
-                f"'{val}' is invalid value for rating."
-                f'Possible values - { *allowed_choices, }'
-            )
-        rating = None
-        try:
-            rating = int(data['rating'])
-        except ValueError:
-            abort(400, message=(invalid_value_msg(data['rating'])))
-
-        if rating not in allowed_choices:
-            abort(422, message=(invalid_value_msg(data['rating'])))
-
+    def check_for_system(inventory_id):
         system = System.query.filter(
             System.inventory_id == inventory_id
         ).first()
@@ -51,8 +49,46 @@ class RecommendationRatingsApi(Resource):
         if system is None:
             abort(404, message=f"System {inventory_id} doesn't exist")
 
+        return system.id
+
+    def validate_request(*args, **kwargs):
+        username = check_for_user()
+        data = json.loads(request.data)
+        inventory_id = data['inventory_id']
+        system_id = check_for_system(inventory_id)
+        rating = check_for_rating(data)
+        new_kwargs = {
+            'rating': rating, 'username': username,
+            'inventory_id': inventory_id, 'system_id': system_id
+        }
+        new_kwargs.update(kwargs)
+        return func(*args, **new_kwargs)
+
+    return validate_request
+
+
+class RecommendationRatingsApi(Resource):
+
+    rating_fields = {
+        'inventory_id': fields.String,
+        'rating': fields.Integer
+    }
+
+    @validate_rating_post_api
+    @marshal_with(rating_fields)
+    def post(self, **kwargs):
+        """
+            Add or update a rating for a system, by system ID.
+            Return the new rating. Any previous rating for this rule by this
+            user is amended to the current value.
+        """
+        username = kwargs.get('username')
+        inventory_id = kwargs.get('inventory_id')
+        rating = kwargs.get('rating')
+        system_id = kwargs.get('system_id')
+
         rating_record = RecommendationRating.query.filter(
-            RecommendationRating.system_id == system.id,
+            RecommendationRating.system_id == system_id,
             RecommendationRating.rated_by == username).first()
 
         if rating_record:
@@ -61,7 +97,7 @@ class RecommendationRatingsApi(Resource):
             status_code = 200
         else:
             rating_record = RecommendationRating(
-                system_id=system.id, rating=rating, rated_by=username
+                system_id=system_id, rating=rating, rated_by=username
             )
             db.session.add(rating_record)
             db.session.commit()

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -259,6 +259,26 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "System doesn't exist",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input for rating",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -260,8 +260,18 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            }
+                        }
+                    },
                     "404": {
-                        "description": "System doesn't exist",
+                        "description": "Not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -271,7 +281,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input for rating",
+                        "description": "Bad request",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/ros/openapi/openapi.json
+++ b/ros/openapi/openapi.json
@@ -251,7 +251,7 @@
                         }
                     },
                     "422": {
-                        "description": "Invalid input for rating",
+                        "description": "Invalid choice of input for rating",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -180,6 +180,83 @@ def test_system_rating(
         assert test_host_detail.json["rating"] == data_dict['rating']
 
 
+def test_system_rating_with_invalid_args(
+        auth_token,
+        db_setup,
+        db_create_account,
+        db_create_system,
+        db_create_performance_profile
+):
+    with app.test_client() as client:
+        response = client.post(
+            '/api/ros/v1/rating',
+            headers={"x-rh-identity": auth_token},
+            data='inventory_id'
+        )
+        assert response.status_code == 400
+        assert response.json["message"] == 'Decoding JSON has failed.'
+
+
+def test_system_rating_with_invalid_rating_choice(
+        auth_token,
+        db_setup,
+        db_create_account,
+        db_create_system,
+        db_create_performance_profile
+):
+    with app.test_client() as client:
+        data_dict = {
+            "inventory_id": "ee0b9978-fe1b-4191-8408-cbadbd47f7a3",
+            "rating": 4
+        }
+        response = client.post(
+            '/api/ros/v1/rating',
+            headers={"x-rh-identity": auth_token},
+            data=json.dumps(data_dict)
+        )
+        assert response.status_code == 422
+
+
+def test_system_rating_with_invalid_rating_value(
+        auth_token,
+        db_setup,
+        db_create_account,
+        db_create_system,
+        db_create_performance_profile
+):
+    with app.test_client() as client:
+        data_dict = {
+            "inventory_id": "ee0b9978-fe1b-4191-8408-cbadbd47f7a3",
+            "rating": "-1;start-sleep -s 15 #"
+        }
+        response = client.post(
+            '/api/ros/v1/rating',
+            headers={"x-rh-identity": auth_token},
+            data=json.dumps(data_dict)
+        )
+        assert response.status_code == 400
+
+
+def test_system_rating_with_invalid_system(
+        auth_token,
+        db_setup,
+        db_create_account,
+        db_create_system,
+        db_create_performance_profile
+):
+    with app.test_client() as client:
+        data_dict = {
+            "inventory_id": "cbadbd47f7a3",
+            "rating": 1
+        }
+        response = client.post(
+            '/api/ros/v1/rating',
+            headers={"x-rh-identity": auth_token},
+            data=json.dumps(data_dict)
+        )
+        assert response.status_code == 404
+
+
 def test_executive_report(
         auth_token,
         db_setup,


### PR DESCRIPTION
With this commit, server will return proper error code & message instead of 500 server error on submitting invalid value against rating via /recommendation_ratings POST API request.



With latest changes, additionally handled below scenarios:
- when user sends invalid JSON or incorrect JSON format 
- when user sends invalid inventory_id 
