### PR TITLE
RHIROS-933 Endpoint & user-specific API caching

### DIFF
--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -51,6 +51,7 @@ if CLOWDER_ENABLED:
     REDIS_PASSWORD = LoadedConfig.inMemoryDb.password
     REDIS_HOST = LoadedConfig.inMemoryDb.hostname
     REDIS_PORT = LoadedConfig.inMemoryDb.port
+    API_CACHE_TIMEOUT = 3600
     METRICS_PORT = LoadedConfig.metricsPort
     KAFKA_BROKER = LoadedConfig.kafka.brokers[0]
     KAFKA_CACERT_LOCATION = None
@@ -83,6 +84,7 @@ else:
     REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", default="")
     REDIS_HOST = os.getenv("REDIS_HOST", default="localhost")
     REDIS_PORT = os.getenv("REDIS_PORT", default=6379)
+    API_CACHE_TIMEOUT = 1
     INSIGHTS_KAFKA_HOST = os.getenv("INSIGHTS_KAFKA_HOST", "localhost")
     INSIGHTS_KAFKA_PORT = os.getenv("INSIGHTS_KAFKA_PORT", "9092")
     INSIGHTS_KAFKA_ADDRESS = f"{INSIGHTS_KAFKA_HOST}:{INSIGHTS_KAFKA_PORT}"

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -6,7 +6,9 @@ import threading
 import uuid
 import base64
 import json
-from flask import jsonify, make_response
+
+
+from flask import jsonify, make_response, request
 from flask_restful import abort
 from ros.lib.models import (
     RhAccount,
@@ -66,6 +68,10 @@ def identity(request):
         abort(response)
     else:
         return json.loads(base64.b64decode(ident))
+
+
+def api_cache_key(*args):
+    return f"{request.path} - {identity(request)['identity']['user']['email']}"
 
 
 def user_data_from_identity(identity):


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Response caching can help especially with endpoints that,

1. receive the most traffic
2. are resource heavy

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Work in progress
