### PR TITLE
RHIROS-934 Bad filter on join - Executive report v2

### DIFF
--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -431,8 +431,8 @@ class ExecutiveReportAPI(Resource):
             PerformanceProfile.psi_enabled,
             PerformanceProfile.operating_system
         ).select_from(System).join(PerformanceProfile).filter(
-            System.id == PerformanceProfile.system_id
-            and System.id.in_(system_ids_by_org_id(org_id))
+            System.id == PerformanceProfile.system_id,
+            System.id.in_(system_ids_by_org_id(org_id))
         )
 
         systems_with_performance_record_subquery = systems_with_performance_record_queryset.subquery()


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The current executive report join query does not look into `rh_accounts`, technically.
The `and` in the filter for join doesn't really work and neither does complain :shrug: 

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

SQL statement from is_configured,

```
SELECT performance_profile.system_id
FROM performance_profile
WHERE performance_profile.system_id IN (SELECT systems.id AS systems_id
FROM systems
WHERE systems.tenant_id IN (SELECT rh_accounts.id
FROM rh_accounts
WHERE rh_accounts.org_id = %(org_id_1)s))

```

SQL statement from executive_report,

```
SELECT systems.id, systems.state, systems.instance_type, systems.cpu_states, systems.io_states, systems.memory_states, performance_profile.system_id, performance_profile.report_date, performance_profile.rule_hit_details, performance_profile.psi_enabled, performance_profile.operating_system
FROM systems JOIN performance_profile ON systems.id = performance_profile.system_id
WHERE systems.id = performance_profile.system_id
```

The change here leads to this statement for the executive report,


```
SELECT systems.id, systems.state, systems.instance_type, systems.cpu_states, systems.io_states, systems.memory_states, performance_profile.system_id, performance_profile.report_date, performance_profile.rule_hit_details, performance_profile.psi_enabled, performance_profile.operating_system
FROM systems JOIN performance_profile ON systems.id = performance_profile.system_id
WHERE systems.id = performance_profile.system_id AND systems.id IN (SELECT systems.id AS systems_id
FROM systems
WHERE systems.tenant_id IN (SELECT rh_accounts.id
FROM rh_accounts
WHERE rh_accounts.org_id = %(org_id_1)s))
```
