### PR TITLE
Ref-RHIROS-892 remove FIXME from os filtering logic

### DIFF
--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -186,9 +186,6 @@ class HostsApi(Resource):
         if operating_systems := request.args.getlist('os'):
             modified_operating_systems = []
             for os in operating_systems:
-                # FIXME: remove `if` block after getting OS values as numeric from frontend
-                if "RHEL" in os:
-                    os = os.split(" ")[1]
                 if os.replace('.', '', 1).isdigit():
                     os_object = {"name": "RHEL"}
                     if len(os) == 1:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

As of now, UI is sending numeric values for OS versions like 8.4
## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
