### PR TITLE
Add COMPONENTS env variable in pr_check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -5,6 +5,7 @@
 # --------------------------------------------
 export APP_NAME="ros"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="ros-backend"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+export COMPONENTS="ros-backend"
 export IMAGE="quay.io/cloudservices/ros-backend"
 export DOCKERFILE="Dockerfile"
 


### PR DESCRIPTION
## PR Title :boom:

pr_check job by default deploy all the components present in app-interface. Setting COMPONENTS variable explicitly specify which component to deploy. 

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

**PR not worth of creating the issue in JIRA**



## Why do we need this change? 
PR check job is failing as we have added new resource template for ros-ocp in app-interface
https://ci.int.devshift.net/job/RedHatInsights-ros-backend-pr-check/446/console

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

