### PR TITLE
RHIROS-623 show iso format date in api endpoints

### DIFF
--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -92,7 +92,7 @@ class HostsApi(Resource):
         'instance_type': fields.String,
         'idling_time': fields.String,
         'os': fields.String,
-        'report_date': fields.String
+        'report_date': fields.DateTime(dt_format='iso8601')
     }
     meta_fields = {
         'count': fields.Integer,
@@ -266,7 +266,7 @@ class HostDetailsApi(Resource):
         'rating': fields.Integer,
         'number_of_suggestions': fields.Integer(attribute='number_of_recommendations'),
         'state': fields.String,
-        'report_date': fields.String,
+        'report_date': fields.DateTime(dt_format='iso8601'),
         'instance_type': fields.String,
         'cloud_provider': fields.String,
         'idling_time': fields.String,
@@ -317,7 +317,7 @@ class HostHistoryApi(Resource):
         'memory': fields.Integer,
         'io_all': fields.Raw,
         'max_io': fields.Float,
-        'report_date': fields.String
+        'report_date': fields.DateTime(dt_format='iso8601')
     }
     meta_fields = {
         'count': fields.Integer,


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Use iso format for `report_date`. 
![Screenshot from 2023-02-22 19-48-59](https://user-images.githubusercontent.com/61837065/220649632-6aa314b7-7d00-4be1-8ff1-82bfb6589b2e.png)

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [X] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added