### PR TITLE
Fixes #RHIROS-1046 - Added env variable in docker-compose

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - PAYLOAD_TRACKER_ENABLED=false
       - XJOIN_GRAPHQL_URL=http://xjoin:4000/graphql
+      - prometheus_multiproc_dir=/tmp
     depends_on:
        - kafka-create-topics
        - db-host-inventory


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Unable to hit inventory API in local setup. 
```
curl http://localhost:8001/api/inventory/v1/hosts
curl: (7) Failed to connect to localhost port 8001 after 0 ms: Connection refused 
```

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [x] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
