### PR TITLE
RHIROS-1063 add psi_enabled field under HostDetailsApi

### DIFF
--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -270,6 +270,7 @@ class HostDetailsApi(Resource):
         'cloud_provider': fields.String,
         'idling_time': fields.String,
         'os': fields.String,
+        'psi_enabled': fields.Boolean
     }
 
     @marshal_with(profile_fields)
@@ -303,6 +304,7 @@ class HostDetailsApi(Resource):
             record['idling_time'] = profile.idling_time
             record['os'] = system.deserialize_host_os_data
             record['number_of_recommendations'] = profile.number_of_recommendations
+            record['psi_enabled'] = profile.psi_enabled
         else:
             abort(404, message="System {} doesn't exist"
                   .format(host_id))


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

To show psi-related info under ROS details page. 
Parent card : [RHIROS-663](https://issues.redhat.com/browse/RHIROS-663)

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
