### PR TITLE
Update Build-Deploy Script

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -5,6 +5,7 @@ set -exv
 IMAGE_NAME="quay.io/cloudservices/ros-backend"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 ADDITIONAL_TAGS="qa latest"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -25,8 +26,8 @@ docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${IMAGE_TAG}"
 
 
 if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
-    docker --config="$DOCKER_CONF" tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:security-compliance"
-    docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:security-compliance"
+    docker --config="$DOCKER_CONF" tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${SECURITY_COMPLIANCE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${SECURITY_COMPLIANCE_TAG}"
 else
     for ADDITIONAL_TAG in $ADDITIONAL_TAGS; do
         docker --config="$DOCKER_CONF" tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${ADDITIONAL_TAG}"


### PR DESCRIPTION
## PR Title :boom:

This PR is to update the `build_deploy.sh` script with the `SECURITY_COMPLIANCE_TAG` variable. 

This variable aids in the automated weekly builds based on the `security-compliance` branch to be tagged in the following manner, sc-YYYYMMDD. 

- _(e.g., sc-20230501)_

## Why do we need this change? :thought_balloon:

This PR is to aid in the weekly automated rebuild of the `security-compliance` branch test image.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)
