### PR TITLE
RHIROS-1122  Create for existing system on Managed Inventory

### DIFF
--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -119,9 +119,10 @@ class InventoryEventsConsumer:
         """ Store new system information (stale, stale_warning timestamp) and return internal DB id"""
         host = msg['host']
         with app.app_context():
+            # 'platform_metadata' field not included when the host is updated via the API.
             if (
                     msg.get('type') == 'updated'
-                    and msg.get("platform_metadata") is None  # Handles valid update for a ROS system
+                    and msg.get("platform_metadata") is None
             ):
                 system_fields = {
                     "inventory_id": host['id'],

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -119,7 +119,7 @@ class InventoryEventsConsumer:
         """ Store new system information (stale, stale_warning timestamp) and return internal DB id"""
         host = msg['host']
         with app.app_context():
-            if msg.get('type') == 'updated':
+            if msg.get("platform_metadata") is None:  # Handles valid update for a ROS system
                 system_fields = {
                     "inventory_id": host['id'],
                     "display_name": host['display_name'],

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -119,7 +119,10 @@ class InventoryEventsConsumer:
         """ Store new system information (stale, stale_warning timestamp) and return internal DB id"""
         host = msg['host']
         with app.app_context():
-            if msg.get("platform_metadata") is None:  # Handles valid update for a ROS system
+            if (
+                    msg.get('type') == 'updated'
+                    and msg.get("platform_metadata") is None  # Handles valid update for a ROS system
+            ):
                 system_fields = {
                     "inventory_id": host['id'],
                     "display_name": host['display_name'],


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Scenario:

When ROS is enabled for an existing System on Managed Inventory, the event type is 'updated'.

Changes:
1. Checking for system_metadata along with msg type
2. Assert valid update on inventory consumer with system_metadata

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Tested with local inventory PATCH:
```
inventory-patch-upload:
   curl -X PATCH "[http://localhost:8001/api/inventory/v1/hosts/{1ca44105-16a0-45a7-b33a-d56d781a0c7b}](http://localhost:8001/api/inventory/v1/hosts/%7B1ca44105-16a0-45a7-b33a-d56d781a0c7b%7D)" \
       -H "x-rh-identity: ${b64_identity}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
       -d '{"display_name": "host1.mydomain.com"}'
```
Update event being handled:

![Screenshot from 2023-05-09 18-01-20](https://github.com/RedHatInsights/ros-backend/assets/6542058/029492a6-a904-4b52-a54d-481b0d509625)




