### PR TITLE
Add redis as required dependency for Puptoo

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -137,6 +137,7 @@ services:
       - KAFKA_ALLOW_CREATE_TOPICS=True
       - DISABLE_PROMETHEUS=True
     depends_on:
+      - redis
       - kafka
       - ingress
     # Not yet used, we are not running clowder ATM


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

We need to explicitly start redis or it should be added as dependency for Puptoo. The local setup stopped working as Puptoo depends on redis however it was not getting started as dependency,

~~~
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/src/puptoo/app.py", line 133, in main
    handle_retries(redis, extra["request_id"])
  File "/usr/local/lib/python3.8/site-packages/src/puptoo/app.py", line 81, in handle_retries
    count = redis.get(request_id)
  File "/usr/local/lib/python3.8/site-packages/redis/commands/core.py", line 1801, in get
    return self.execute_command("GET", name)
  File "/usr/local/lib/python3.8/site-packages/redis/client.py", line 1266, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/usr/local/lib/python3.8/site-packages/redis/connection.py", line 1457, in get_connection
    connection.connect()
  File "/usr/local/lib/python3.8/site-packages/redis/connection.py", line 705, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error -2 connecting to redis:6379. Name or service not known.
~~~

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
