### PR TITLE
Run redis over ssl when password is present

### DIFF
--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -118,7 +118,8 @@ DB_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}"\
 DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", '5'))
 DB_MAX_OVERFLOW = int(os.getenv("DB_MAX_OVERFLOW", '10'))
 REDIS_AUTH = f"{REDIS_USERNAME or ''}:{REDIS_PASSWORD}@" if REDIS_PASSWORD else ""
-REDIS_URL = f"redis://{REDIS_AUTH}{REDIS_HOST}:{REDIS_PORT}"
+REDIS_SCHEME = "rediss://" if REDIS_PASSWORD else "redis://"
+REDIS_URL = f"{REDIS_SCHEME}{REDIS_AUTH}{REDIS_HOST}:{REDIS_PORT}"
 GROUP_ID = os.getenv('GROUP_ID', 'resource-optimization')
 # The default value for PATH_PREFIX is same as under clowdapp file
 PATH_PREFIX = os.getenv("PATH_PREFIX", "/api")


### PR DESCRIPTION
## PR Title :boom:

Forcing redis to run over SSL when password is present as in app-interface. 

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Updating all of the various apps that will be running in environments where SSL is enforced we need to toggle `redis://` -> `rediss://` when the password is present.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
