### PR TITLE
update is_ros flag

### DIFF
--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -265,7 +265,7 @@ def highlights_instance_types(queryset, highlight_type):
 
 
 def system_allowed_in_ros(msg, reporter):
-    is_ros = None
+    is_ros = False
     cloud_provider = ''
     if reporter == 'INSIGHTS ENGINE':
         is_ros = msg["input"]["platform_metadata"].get("is_ros")

--- a/tests/data_files/events-message.json
+++ b/tests/data_files/events-message.json
@@ -1149,7 +1149,7 @@
     "b64_identity": "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMSIsInR5cGUiOiAiVXNlciIsInVzZXIiOiB7InVzZXJuYW1lIjogInR1c2VyQHJlZGhhdC5jb20iLCJlbWFpbCI6ICJ0dXNlckByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6ICJ0ZXN0IiwibGFzdF9uYW1lIjogInVzZXIiLCJpc19hY3RpdmUiOiB0cnVlLCJpc19vcmdfYWRtaW4iOiBmYWxzZSwgImlzX2ludGVybmFsIjogdHJ1ZSwgImxvY2FsZSI6ICJlbl9VUyJ9LCJpbnRlcm5hbCI6IHsgIm9yZ19pZCI6ICIwMDAwMDEifX19Cg==",
     "timestamp": "2021-03-26T05:39:42.650719645Z",
     "elapsed_time": 1616737184.762391,
-    "is_ros": "true"
+    "is_ros": true
   },
   "metadata": {
     "request_id": "9b71e84c406a/ZmPCkYGwiY-000012"

--- a/tests/data_files/insights-engine-result-idle.json
+++ b/tests/data_files/insights-engine-result-idle.json
@@ -23,7 +23,7 @@
         "url": "http://minio:9000/insights-upload-perma/7bc5e4526e8b/iSA5PcbSgL-000002?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211230%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211230T125436Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=4a7238fb0dd8e69018a78693a36412cabc76fb18811d632c6a014fa96e276f8e",
         "validation": null,
         "test": null,
-        "is_ros": "true"
+        "is_ros": true
       },
       "metadata": {
         "request_id": "7bc5e4526e8b/iSA5PcbSgL-000002"

--- a/tests/data_files/insights-engine-result-no-pcp.json
+++ b/tests/data_files/insights-engine-result-no-pcp.json
@@ -23,7 +23,7 @@
 			"url": "http://minio:9000/insights-upload-perma/f77010e80955/miYkbDetAo-000007?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211229%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211229T081304Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=1cfb9076ed2597424033e9ad1dad73b5d75397c672ab9fd98f14316a250f84a6",
 			"validation": null,
 			"test": null,
-			"is_ros": "true"
+			"is_ros": true
 		},
 		"metadata": {
 			"request_id": "f77010e80955/miYkbDetAo-000007"

--- a/tests/data_files/insights-engine-result-optimized.json
+++ b/tests/data_files/insights-engine-result-optimized.json
@@ -23,7 +23,7 @@
             "url": "http://minio:9000/insights-upload-perma/f77010e80955/miYkbDetAo-000004?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211229%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211229T065252Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=9d0f37a4d72eb5f54ad17ceff31275783332b63e52853bc00c224ba838d27a75",
             "validation": null,
             "test": null,
-            "is_ros": "true"
+            "is_ros": true
         },
         "metadata": {
             "request_id": "f77010e80955/miYkbDetAo-000004"

--- a/tests/data_files/insights-engine-result-under-pressure.json
+++ b/tests/data_files/insights-engine-result-under-pressure.json
@@ -23,7 +23,7 @@
       "url": "http://minio:9000/insights-upload-perma/0efcf25fadb1/nD2IJ8jDVD-000055?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211215%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211215T133804Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=ebff2cf90984c7b6cfc265cd7793b265a3a88722969f683c6cd1b6c8fe553a07",
       "validation": null,
       "test": null,
-      "is_ros": "true"
+      "is_ros": true
     },
     "metadata": {
       "request_id": "0efcf25fadb1/nD2IJ8jDVD-000055"

--- a/tests/data_files/insights-engine-result-undersized.json
+++ b/tests/data_files/insights-engine-result-undersized.json
@@ -23,7 +23,7 @@
 			"url": "http://minio:9000/insights-upload-perma/f77010e80955/miYkbDetAo-000008?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=BQA2GEXO711FVBVXDWKM%2F20211229%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211229T083508Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=7974a2afce5640213e29e1dd6900737dd94a6482fec0236da251223c712ee4bf",
 			"validation": null,
 			"test": null,
-			"is_ros": "true"
+			"is_ros": true
 		},
 		"metadata": {
 			"request_id": "f77010e80955/miYkbDetAo-000008"


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Update `is_ros` field from `string` to `boolean` as Puptoo is now sending `boolean` value.
Ref - [ESSNTL-4611](https://issues.redhat.com/browse/ESSNTL-4611)

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added