### PR TITLE
Ref-RHIROS-1156 handle default value for group

### DIFF
--- a/migrations/versions/1051e0d7e62e_update_default_value_for_group_column.py
+++ b/migrations/versions/1051e0d7e62e_update_default_value_for_group_column.py
@@ -1,0 +1,24 @@
+"""update default value for group column
+
+Revision ID: 1051e0d7e62e
+Revises: b21a2ec1a281
+Create Date: 2023-07-21 20:50:08.705356
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1051e0d7e62e'
+down_revision = 'b21a2ec1a281'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('systems', 'groups', server_default=sa.text("'[]'"))
+
+
+def downgrade():
+    pass

--- a/migrations/versions/1051e0d7e62e_update_default_value_for_group_column.py
+++ b/migrations/versions/1051e0d7e62e_update_default_value_for_group_column.py
@@ -18,6 +18,7 @@ depends_on = None
 
 def upgrade():
     op.alter_column('systems', 'groups', server_default=sa.text("'[]'"))
+    op.execute("UPDATE systems SET groups= '[]' WHERE groups IS NULL")
 
 
 def downgrade():

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -58,7 +58,8 @@ def db_create_system(db_create_account):
         operating_system={"name": "RHEL", "major": 8, "minor": 4},
         cpu_states=['CPU_UNDERSIZED', 'CPU_UNDERSIZED_BY_PRESSURE'],
         io_states=['IO_UNDERSIZED_BY_PRESSURE'],
-        memory_states=['MEMORY_UNDERSIZED', 'MEMORY_UNDERSIZED_BY_PRESSURE']
+        memory_states=['MEMORY_UNDERSIZED', 'MEMORY_UNDERSIZED_BY_PRESSURE'],
+        groups=[]
     )
 
     db.session.add(system)

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -58,8 +58,7 @@ def db_create_system(db_create_account):
         operating_system={"name": "RHEL", "major": 8, "minor": 4},
         cpu_states=['CPU_UNDERSIZED', 'CPU_UNDERSIZED_BY_PRESSURE'],
         io_states=['IO_UNDERSIZED_BY_PRESSURE'],
-        memory_states=['MEMORY_UNDERSIZED', 'MEMORY_UNDERSIZED_BY_PRESSURE'],
-        groups=[]
+        memory_states=['MEMORY_UNDERSIZED', 'MEMORY_UNDERSIZED_BY_PRESSURE']
     )
 
     db.session.add(system)


### PR DESCRIPTION
## Migration to handle group default value :boom:

Ref-RHIROS-1156 handle default value for group

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
