### PR TITLE
Fixes #RHIROS-1266 - Add groups support through RBAC

### DIFF
--- a/ros/api/common/add_group_filter.py
+++ b/ros/api/common/add_group_filter.py
@@ -1,0 +1,10 @@
+from ros.lib.models import System
+
+
+def include_group_filter(request, query):
+    if hasattr(request, "host_groups"):
+        if len(request.host_groups) > 1 or (len(request.host_groups) == 0 and request.host_groups[0] is not None):
+            query = query.filter(System.groups[0]['id'].astext.in_(request.host_groups) | (System.groups == '[]'))
+        else:
+            query = query.filter((System.groups == '[]'))
+    return query

--- a/ros/api/common/add_group_filter.py
+++ b/ros/api/common/add_group_filter.py
@@ -1,7 +1,8 @@
 from ros.lib.models import System
+from flask_restful import request
 
 
-def include_group_filter(request, query):
+def group_filtered_query(query):
     if hasattr(request, "host_groups"):
         if len(request.host_groups) > 1 or (len(request.host_groups) == 0 and request.host_groups[0] is not None):
             query = query.filter(System.groups[0]['id'].astext.in_(request.host_groups) | (System.groups == '[]'))

--- a/ros/api/common/add_group_filter.py
+++ b/ros/api/common/add_group_filter.py
@@ -4,8 +4,9 @@ from flask_restful import request
 
 def group_filtered_query(query):
     if hasattr(request, "host_groups"):
-        if len(request.host_groups) > 1 or (len(request.host_groups) == 0 and request.host_groups[0] is not None):
-            query = query.filter(System.groups[0]['id'].astext.in_(request.host_groups) | (System.groups == '[]'))
+        host_groups = [gid for gid in request.host_groups if gid is not None]
+        if len(host_groups) > 1:
+            query = query.filter(System.groups[0]['id'].astext.in_(host_groups) | (System.groups == '[]'))
         else:
             query = query.filter((System.groups == '[]'))
     return query

--- a/ros/api/common/utils.py
+++ b/ros/api/common/utils.py
@@ -11,6 +11,7 @@ from ros.lib.utils import (
 )
 from ros.extensions import db
 from sqlalchemy import exc
+from ros.api.common.add_group_filter import include_group_filter
 
 LOG = logging.getLogger(__name__)
 prefix = "VALIDATE REQUEST"
@@ -56,7 +57,8 @@ def validate_rating_data(func):
         system_id = None
         if not is_valid_uuid(inventory_id):
             abort(404, message='Invalid inventory_id, Id should be in form of UUID4')
-        systems = system_ids_by_org_id(ident['org_id']).filter(System.inventory_id == inventory_id)
+        sys_query = include_group_filter(request, system_ids_by_org_id(ident['org_id']))
+        systems = sys_query.filter(System.inventory_id == inventory_id)
         try:
             system_id = db.session.execute(systems).scalar_one()
         except exc.NoResultFound:

--- a/ros/api/common/utils.py
+++ b/ros/api/common/utils.py
@@ -11,7 +11,7 @@ from ros.lib.utils import (
 )
 from ros.extensions import db
 from sqlalchemy import exc
-from ros.api.common.add_group_filter import include_group_filter
+from ros.api.common.add_group_filter import group_filtered_query
 
 LOG = logging.getLogger(__name__)
 prefix = "VALIDATE REQUEST"
@@ -57,8 +57,8 @@ def validate_rating_data(func):
         system_id = None
         if not is_valid_uuid(inventory_id):
             abort(404, message='Invalid inventory_id, Id should be in form of UUID4')
-        sys_query = include_group_filter(request, system_ids_by_org_id(ident['org_id']))
-        systems = sys_query.filter(System.inventory_id == inventory_id)
+        systems = group_filtered_query(system_ids_by_org_id(ident['org_id']).
+                                       filter(System.inventory_id == inventory_id))
         try:
             system_id = db.session.execute(systems).scalar_one()
         except exc.NoResultFound:

--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -6,7 +6,7 @@ from ros.lib.constants import SubStates
 from datetime import datetime, timedelta, timezone
 from sqlalchemy import asc, desc, nullslast, nullsfirst
 from flask_restful import Resource, abort, fields, marshal_with
-from ros.api.common.add_group_filter import include_group_filter
+from ros.api.common.add_group_filter import group_filtered_query
 
 from ros.lib.models import (
     db,
@@ -54,7 +54,7 @@ SYSTEM_COLUMNS = [
 class IsROSConfiguredApi(Resource):
     def get(self):
         org_id = org_id_from_identity_header(request)
-        query = include_group_filter(request, systems_ids_for_existing_profiles(org_id))
+        query = group_filtered_query(systems_ids_for_existing_profiles(org_id))
         system_count = query.count()
         systems_with_suggestions = query.filter(PerformanceProfile.number_of_recommendations > 0).count()
         systems_waiting_for_data = query.filter(PerformanceProfile.state == 'Waiting for data').count()
@@ -133,7 +133,8 @@ class HostsApi(Resource):
         # that constrains the result rows into a unique order.
         # Otherwise you will get an unpredictable subset of the query's rows.
         # Refer - https://www.postgresql.org/docs/13/queries-limit.html
-        sys_query = include_group_filter(request, system_ids_by_org_id(org_id))
+
+        sys_query = group_filtered_query(system_ids_by_org_id(org_id))
         system_query = sys_query.filter(*self.build_system_filters())
         sort_expression = self.build_sort_expression(order_how, order_by)
         query = (
@@ -292,9 +293,7 @@ class HostDetailsApi(Resource):
         user = user_data_from_identity(ident)
         username = user['username'] if 'username' in user else None
         org_id = org_id_from_identity_header(request)
-
-        sys_query = include_group_filter(request, system_ids_by_org_id(org_id))
-        system_query = sys_query.filter(System.inventory_id == host_id)
+        system_query = group_filtered_query(system_ids_by_org_id(org_id).filter(System.inventory_id == host_id))
 
         profile = PerformanceProfile.query.filter(
             PerformanceProfile.system_id.in_(system_query)).first()
@@ -357,9 +356,7 @@ class HostHistoryApi(Resource):
             abort(404, message='Invalid host_id, Id should be in form of UUID4')
 
         org_id = org_id_from_identity_header(request)
-
-        sys_query = include_group_filter(request, system_ids_by_org_id(org_id))
-        system_query = sys_query.filter(System.inventory_id == host_id)
+        system_query = group_filtered_query(system_ids_by_org_id(org_id).filter(System.inventory_id == host_id))
 
         query = PerformanceProfileHistory.query.filter(
             PerformanceProfileHistory.system_id.in_(system_query)
@@ -446,7 +443,7 @@ class ExecutiveReportAPI(Resource):
             System.id.in_(system_ids_by_org_id(org_id))
         )
 
-        sys_query = include_group_filter(request, systems_with_performance_record_queryset)
+        sys_query = group_filtered_query(systems_with_performance_record_queryset)
         systems_with_performance_record_subquery = sys_query.subquery()
 
         # System counts

--- a/ros/api/v1/hosts.py
+++ b/ros/api/v1/hosts.py
@@ -6,6 +6,7 @@ from ros.lib.constants import SubStates
 from datetime import datetime, timedelta, timezone
 from sqlalchemy import asc, desc, nullslast, nullsfirst
 from flask_restful import Resource, abort, fields, marshal_with
+from ros.api.common.add_group_filter import include_group_filter
 
 from ros.lib.models import (
     db,
@@ -33,7 +34,6 @@ from ros.api.common.pagination import (
     build_paginated_system_list_response
 )
 
-
 LOG = logging.getLogger(__name__)
 SYSTEM_STATES_EXCEPT_EMPTY = [
     "Oversized", "Undersized", "Idling", "Under pressure", "Storage rightsizing", "Optimized", "Waiting for data"
@@ -54,7 +54,7 @@ SYSTEM_COLUMNS = [
 class IsROSConfiguredApi(Resource):
     def get(self):
         org_id = org_id_from_identity_header(request)
-        query = systems_ids_for_existing_profiles(org_id)
+        query = include_group_filter(request, systems_ids_for_existing_profiles(org_id))
         system_count = query.count()
         systems_with_suggestions = query.filter(PerformanceProfile.number_of_recommendations > 0).count()
         systems_waiting_for_data = query.filter(PerformanceProfile.state == 'Waiting for data').count()
@@ -133,10 +133,9 @@ class HostsApi(Resource):
         # that constrains the result rows into a unique order.
         # Otherwise you will get an unpredictable subset of the query's rows.
         # Refer - https://www.postgresql.org/docs/13/queries-limit.html
-
-        system_query = system_ids_by_org_id(org_id).filter(*self.build_system_filters())
+        sys_query = include_group_filter(request, system_ids_by_org_id(org_id))
+        system_query = sys_query.filter(*self.build_system_filters())
         sort_expression = self.build_sort_expression(order_how, order_by)
-
         query = (
             db.session.query(PerformanceProfile, System, RhAccount)
             .join(System, System.id == PerformanceProfile.system_id)
@@ -294,7 +293,8 @@ class HostDetailsApi(Resource):
         username = user['username'] if 'username' in user else None
         org_id = org_id_from_identity_header(request)
 
-        system_query = system_ids_by_org_id(org_id).filter(System.inventory_id == host_id)
+        sys_query = include_group_filter(request, system_ids_by_org_id(org_id))
+        system_query = sys_query.filter(System.inventory_id == host_id)
 
         profile = PerformanceProfile.query.filter(
             PerformanceProfile.system_id.in_(system_query)).first()
@@ -358,7 +358,8 @@ class HostHistoryApi(Resource):
 
         org_id = org_id_from_identity_header(request)
 
-        system_query = system_ids_by_org_id(org_id).filter(System.inventory_id == host_id)
+        sys_query = include_group_filter(request, system_ids_by_org_id(org_id))
+        system_query = sys_query.filter(System.inventory_id == host_id)
 
         query = PerformanceProfileHistory.query.filter(
             PerformanceProfileHistory.system_id.in_(system_query)
@@ -386,7 +387,6 @@ class HostHistoryApi(Resource):
 
 
 class ExecutiveReportAPI(Resource):
-
     count_and_percentage = {
         "count": fields.Integer,
         "percentage": fields.Float
@@ -435,6 +435,7 @@ class ExecutiveReportAPI(Resource):
             System.io_states,
             System.memory_states,
             System.region,
+            System.groups,
             PerformanceProfile.system_id,
             PerformanceProfile.report_date,
             PerformanceProfile.rule_hit_details,
@@ -445,7 +446,8 @@ class ExecutiveReportAPI(Resource):
             System.id.in_(system_ids_by_org_id(org_id))
         )
 
-        systems_with_performance_record_subquery = systems_with_performance_record_queryset.subquery()
+        sys_query = include_group_filter(request, systems_with_performance_record_queryset)
+        systems_with_performance_record_subquery = sys_query.subquery()
 
         # System counts
         total_systems = systems_with_performance_record_queryset.count()

--- a/ros/api/v1/recommendation_ratings.py
+++ b/ros/api/v1/recommendation_ratings.py
@@ -1,13 +1,14 @@
 from flask_restful import Resource, fields, marshal_with
 from ros.lib.models import RecommendationRating, db
 from ros.api.common.utils import validate_rating_data
+from ros.lib.models import System
 
 
 class RecommendationRatingsApi(Resource):
-
     rating_fields = {
         'inventory_id': fields.String,
-        'rating': fields.Integer
+        'rating': fields.Integer,
+        'group_id': fields.String,
     }
 
     @validate_rating_data
@@ -22,6 +23,17 @@ class RecommendationRatingsApi(Resource):
         inventory_id = kwargs.get('inventory_id')
         rating = kwargs.get('rating')
         system_id = kwargs.get('system_id')
+        group_id = kwargs.get('group_id', '')
+        if group_id:
+            sys_query = db.session.query(System.inventory_id). \
+                filter((System.inventory_id == inventory_id) &
+                       ((System.groups[0]['id'].astext == group_id) | (System.groups == '[]')))
+        else:
+            sys_query = db.session.query(System.inventory_id). \
+                filter((System.inventory_id == inventory_id) & (System.groups == '[]'))
+
+        if sys_query.count() == 0:
+            return {}, 401
 
         rating_record = RecommendationRating.query.filter(
             RecommendationRating.system_id == system_id,

--- a/ros/api/v1/recommendation_ratings.py
+++ b/ros/api/v1/recommendation_ratings.py
@@ -1,14 +1,13 @@
 from flask_restful import Resource, fields, marshal_with
 from ros.lib.models import RecommendationRating, db
 from ros.api.common.utils import validate_rating_data
-from ros.lib.models import System
 
 
 class RecommendationRatingsApi(Resource):
+
     rating_fields = {
         'inventory_id': fields.String,
-        'rating': fields.Integer,
-        'group_id': fields.String,
+        'rating': fields.Integer
     }
 
     @validate_rating_data
@@ -23,17 +22,6 @@ class RecommendationRatingsApi(Resource):
         inventory_id = kwargs.get('inventory_id')
         rating = kwargs.get('rating')
         system_id = kwargs.get('system_id')
-        group_id = kwargs.get('group_id', '')
-        if group_id:
-            sys_query = db.session.query(System.inventory_id). \
-                filter((System.inventory_id == inventory_id) &
-                       ((System.groups[0]['id'].astext == group_id) | (System.groups == '[]')))
-        else:
-            sys_query = db.session.query(System.inventory_id). \
-                filter((System.inventory_id == inventory_id) & (System.groups == '[]'))
-
-        if sys_query.count() == 0:
-            return {}, 401
 
         rating_record = RecommendationRating.query.filter(
             RecommendationRating.system_id == system_id,

--- a/ros/api/v1/recommendations.py
+++ b/ros/api/v1/recommendations.py
@@ -4,7 +4,7 @@ from ros.api.modules.recommendations import Recommendation
 from flask_restful import Resource, abort, fields, marshal_with
 from flask import request
 from sqlalchemy import exc
-from ros.api.common.add_group_filter import include_group_filter
+from ros.api.common.add_group_filter import group_filtered_query
 
 
 class RecommendationsApi(Resource):
@@ -39,8 +39,8 @@ class RecommendationsApi(Resource):
         ident = identity(request)['identity']
 
         filter_description = request.args.get('description')
-        sys_query = include_group_filter(request, system_ids_by_org_id(ident['org_id'], True))
-        system_query = sys_query.filter(System.inventory_id == host_id)
+        system_query = group_filtered_query(system_ids_by_org_id(ident['org_id'], True).
+                                            filter(System.inventory_id == host_id))
         try:
             system = db.session.execute(system_query).scalar_one()
         except exc.NoResultFound:

--- a/ros/api/v1/recommendations.py
+++ b/ros/api/v1/recommendations.py
@@ -4,6 +4,7 @@ from ros.api.modules.recommendations import Recommendation
 from flask_restful import Resource, abort, fields, marshal_with
 from flask import request
 from sqlalchemy import exc
+from ros.api.common.add_group_filter import include_group_filter
 
 
 class RecommendationsApi(Resource):
@@ -38,8 +39,8 @@ class RecommendationsApi(Resource):
         ident = identity(request)['identity']
 
         filter_description = request.args.get('description')
-
-        system_query = system_ids_by_org_id(ident['org_id'], True).filter(System.inventory_id == host_id)
+        sys_query = include_group_filter(request, system_ids_by_org_id(ident['org_id'], True))
+        system_query = sys_query.filter(System.inventory_id == host_id)
         try:
             system = db.session.execute(system_query).scalar_one()
         except exc.NoResultFound:

--- a/ros/lib/rbac_interface.py
+++ b/ros/lib/rbac_interface.py
@@ -131,7 +131,7 @@ def set_host_groups(rbac_response):
       "resourceDefinitions": [
         {
           "attributeFilter": {
-            "key": "inventory.groups",
+            "key": "group.id",
             "value": [
               "group 1",
               "group 2"
@@ -144,7 +144,7 @@ def set_host_groups(rbac_response):
     }
 
     If the permission is 'inventory:hosts:read', we find one of the resource
-    definitions that has an attribute filter key of 'inventory.groups', and
+    definitions that has an attribute filter key of 'group.id', and
     we get the list of inventory groups from its value. We currently ignore
     the operation value.
     """

--- a/ros/lib/rbac_interface.py
+++ b/ros/lib/rbac_interface.py
@@ -3,11 +3,14 @@ from http import HTTPStatus
 from flask_restful import abort
 from .config import RBAC_SVC_URL, ENABLE_RBAC, TLS_CA_PATH
 import requests
-
+import json
+from ros.lib.config import get_logger
 
 RBAC_SVC_ENDPOINT = "/api/rbac/v1/access/?application=%s"
 AUTH_HEADER_NAME = "X-RH-IDENTITY"
 VALID_HTTP_VERBS = ["get", "options", "head", "post", "put", "patch", "delete"]
+LOG = get_logger(__name__)
+host_group_attr = 'host_groups'
 
 
 def fetch_url(url, auth_header, logger, method="get"):
@@ -61,19 +64,19 @@ def get_key_from_headers(incoming_headers):
     return incoming_headers.get(AUTH_HEADER_NAME)
 
 
-def get_perms(application, auth_key, logger):
+def query_rbac(application, auth_key, logger):
     """
     check if user has a permission
     """
-
     auth_header = {AUTH_HEADER_NAME: auth_key}
-
     rbac_location = urljoin(RBAC_SVC_URL, RBAC_SVC_ENDPOINT) % application
-
     rbac_result = fetch_url(
         rbac_location, auth_header, logger)
-    perms = [perm["permission"] for perm in rbac_result["data"]]
+    return rbac_result
 
+
+def get_perms(result):
+    perms = [perm["permission"] for perm in result["data"]]
     return perms
 
 
@@ -83,24 +86,28 @@ def ensure_has_permission(**kwargs):
     permissions, application, app_name, request, logger
     """
 
+    if not ENABLE_RBAC:
+        return
+
     request = kwargs["request"]
     auth_key = request.headers.get('X-RH-IDENTITY')
 
-    if not ENABLE_RBAC:
-        return
+    rbac_response = query_rbac(kwargs["application"], auth_key, kwargs["logger"])
 
     if _is_mgmt_url(request.path):
         return  # allow request
     if auth_key:
-        perms = get_perms(
-            kwargs["application"],
-            auth_key,
-            kwargs["logger"]
-        )
+        perms = get_perms(rbac_response)
         if perms:
             for p in perms:
                 if p in kwargs["permissions"]:
-                    return  # allow
+                    # Allow access and
+                    # Try to set group details on request if any
+                    try:
+                        find_host_groups(request, rbac_response)
+                    except Exception as err:
+                        LOG.info(f"Failed to fetch group details {err}")
+                    return
         # if wrong permissions
         abort(
             HTTPStatus.FORBIDDEN,
@@ -118,3 +125,79 @@ def _is_mgmt_url(path):
     Small helper to test if URL is for management API.
     """
     return path.startswith("/mgmt/")
+
+
+def find_host_groups(request, rbac_response):
+    """
+    We now also have to store the host group information we get from inventory.
+    This comes in the resource definition within the RBAC response:
+
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "inventory.groups",
+            "value": [
+              "group 1",
+              "group 2"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:hosts:read"
+    }
+
+    If the permission is 'inventory:hosts:read', we find one of the resource
+    definitions that has an attribute filter key of 'inventory.groups', and
+    we get the list of inventory groups from its value. We currently ignore
+    the operation value.
+    """
+
+    if rbac_response is None:
+        return  # we can't store any host groups on None
+
+    if 'data' not in rbac_response:
+        LOG.info("Warning: The response from RBAC does not contain 'data' list to fetch group details")
+        return
+
+    role_list = rbac_response['data']
+
+    for role in role_list:
+        if 'permission' not in role:
+            continue
+        if role['permission'] != 'inventory:hosts:read':
+            continue
+        # ignore the failure modes, try moving on to other roles that
+        # also match this permission
+        if 'resourceDefinitions' not in role:
+            continue
+        if not isinstance(role['resourceDefinitions'], list):
+            continue
+        for rscdef in role['resourceDefinitions']:
+            if not isinstance(rscdef, dict):
+                continue
+            if 'attributeFilter' not in rscdef:
+                continue
+            attrfilter = rscdef['attributeFilter']
+            if not isinstance(attrfilter, dict):
+                continue
+            if 'key' not in attrfilter and 'value' not in attrfilter:
+                continue
+            if attrfilter['key'] != 'group.id':
+                continue
+            value = attrfilter['value']
+            # Early versions of the spec say the value is a list; later
+            # versions say it's a string with a JSON-encoded list.  Let's try
+            # to cope with the latter by converting it into the former.
+            if isinstance(value, str) and value[0] == '[' and value[-1] == ']':
+                value = json.loads(value)
+            if not isinstance(value, list):
+                continue
+            # Finally, we have the right key: set its value (a list) as
+            # the 'host_group_attr' property
+            # Maybe it would be good to set values as json here instead of list
+            setattr(request, host_group_attr, value)
+            LOG.info(f"User has host groups {value}")
+            # and we can leave in triumph
+            return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
 pytest_plugins = [
-    "tests.fixtures.db_fixtures"
+    "tests.fixtures.db_fixtures",
+    "tests.fixtures.db_fixtures_for_inventory_groups"
 ]

--- a/tests/data_files/mock_rbac_returns_emtpy_group.json
+++ b/tests/data_files/mock_rbac_returns_emtpy_group.json
@@ -1,0 +1,45 @@
+{
+ "meta": {
+   "count": 5,
+   "limit": 5,
+   "offset": 0
+ },
+ "links": {
+   "first": "/api/rbac/v1/access/?application=advisor%2Cinventory&limit=7&offset=0",
+   "next": null,
+   "previous": null,
+   "last": "/api/rbac/v1/access/?application=advisor%2Cinventory&limit=7&offset=0"
+ },
+  "data": [
+    {
+      "resourceDefinitions": [],
+      "permission": "ros:*:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "value": [
+              null
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:hosts:read"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:hosts:write"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:groups:write"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:groups:read"
+    }
+  ]
+}

--- a/tests/data_files/mock_rbac_returns_groups_including_example_group.json
+++ b/tests/data_files/mock_rbac_returns_groups_including_example_group.json
@@ -1,0 +1,47 @@
+{
+ "meta": {
+   "count": 5,
+   "limit": 5,
+   "offset": 0
+ },
+ "links": {
+   "first": "/api/rbac/v1/access/?application=advisor%2Cinventory&limit=7&offset=0",
+   "next": null,
+   "previous": null,
+   "last": "/api/rbac/v1/access/?application=advisor%2Cinventory&limit=7&offset=0"
+ },
+ "data": [
+   {
+     "resourceDefinitions": [],
+     "permission": "ros:*:*"
+   },
+   {
+     "resourceDefinitions": [
+       {
+         "attributeFilter": {
+           "key": "group.id",
+           "value": [
+             "12345678-fe1b-4191-8408-cbadbd47f7a3",
+             "99999999-d97e-4ed0-9095-ef07d73b4839",
+             null
+           ],
+           "operation": "in"
+         }
+       }
+     ],
+     "permission": "inventory:hosts:read"
+   },
+   {
+     "resourceDefinitions": [],
+     "permission": "inventory:hosts:write"
+   },
+   {
+     "resourceDefinitions": [],
+     "permission": "inventory:groups:write"
+   },
+   {
+     "resourceDefinitions": [],
+     "permission": "inventory:groups:read"
+   }
+ ]
+}

--- a/tests/data_files/mock_rbac_returns_no_groups.json
+++ b/tests/data_files/mock_rbac_returns_no_groups.json
@@ -1,0 +1,41 @@
+{
+ "meta": {
+   "count": 5,
+   "limit": 5,
+   "offset": 0
+ },
+ "links": {
+   "first": "/api/rbac/v1/access/?application=advisor%2Cinventory&limit=7&offset=0",
+   "next": null,
+   "previous": null,
+   "last": "/api/rbac/v1/access/?application=advisor%2Cinventory&limit=7&offset=0"
+ },
+  "data": [
+    {
+      "resourceDefinitions": [],
+      "permission": "ros:*:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:hosts:read"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:hosts:write"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:groups:write"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:groups:read"
+    }
+  ]
+}

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -6,6 +6,33 @@ from ros.lib.app import app
 from ros.extensions import db
 from sqlalchemy_utils import database_exists, create_database, drop_database
 from ros.lib.models import RhAccount, System, PerformanceProfile, Rule, PerformanceProfileHistory
+from base64 import b64encode
+
+
+@pytest.fixture(scope="session")
+def auth_token():
+    identity = {
+        "identity": {
+            "account_number": "12345",
+            "type": "User",
+            "user": {
+                "username": "tuser@redhat.com",
+                "email": "tuser@redhat.com",
+                "first_name": "test",
+                "last_name": "user",
+                "is_active": True,
+                "is_org_admin": False,
+                "is_internal": True,
+                "locale": "en_US"
+            },
+            "org_id": "000001",
+            "internal": {
+                "org_id": "000001"
+            }
+        }
+    }
+    auth_token = b64encode(json.dumps(identity).encode('utf-8'))
+    return auth_token
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/db_fixtures_for_inventory_groups.py
+++ b/tests/fixtures/db_fixtures_for_inventory_groups.py
@@ -1,0 +1,146 @@
+import pytest
+from ros.extensions import db
+from ros.lib.models import System, PerformanceProfile
+import datetime
+
+
+@pytest.fixture
+def system_with_example_group():
+    system = System(
+        id=2,
+        tenant_id=1,
+        inventory_id='12345678-fe1b-4191-8408-cbadbd47f7a3',
+        display_name='ip-181-30-31-32.ap-north-1.compute.internal',
+        fqdn='ip-181-30-31-32.ap-north-1.compute.internal',
+        cloud_provider='aws',
+        instance_type='t2.micro',
+        state='Idling',
+        region='ap-north-1',
+        operating_system={"name": "RHEL", "major": 8, "minor": 9},
+        cpu_states=['CPU_UNDERSIZED', 'CPU_UNDERSIZED_BY_PRESSURE'],
+        io_states=['IO_UNDERSIZED_BY_PRESSURE'],
+        memory_states=['MEMORY_UNDERSIZED', 'MEMORY_UNDERSIZED_BY_PRESSURE'],
+        groups=[{"id": "12345678-fe1b-4191-8408-cbadbd47f7a3", "name": "example-group"}]
+    )
+    db.session.add(system)
+    db.session.commit()
+
+
+@pytest.fixture
+def system_with_test_group():
+    system = System(
+        id=3,
+        tenant_id=1,
+        inventory_id='99999999-d97e-4ed0-9095-ef07d73b4839',
+        display_name='ip-181-33-34-35.ap-north-1.compute.internal',
+        fqdn='ip-181-33-34-35.ap-north-1.compute.internal',
+        cloud_provider='aws',
+        instance_type='t2.micro',
+        state='Idling',
+        region='ap-north-1',
+        operating_system={"name": "RHEL", "major": 8, "minor": 9},
+        cpu_states=['CPU_UNDERSIZED', 'CPU_UNDERSIZED_BY_PRESSURE'],
+        io_states=['IO_UNDERSIZED_BY_PRESSURE'],
+        memory_states=['MEMORY_UNDERSIZED', 'MEMORY_UNDERSIZED_BY_PRESSURE'],
+        groups=[{"id": "abcdefgh-d97e-4ed0-9095-ef07d73b4839", "name": "test-group"}]
+    )
+    db.session.add(system)
+    db.session.commit()
+
+
+@pytest.fixture
+def create_performance_profiles():
+    for sys_id in range(2, 4):
+        db_create_performance_profile(sys_id)
+
+
+def db_create_performance_profile(sys_id):
+
+    # dummy record values
+    performance_record = {
+      "hinv.ncpu": 2.0,
+      "total_cpus": 1,
+      "mem.physmem": 825740.0,
+      "instance_type": "t2.micro",
+      "disk.dev.total": {
+        "xvda": {
+          "val": 0.314,
+          "units": "count / sec"
+        }
+      },
+      "mem.util.available": 825040.0,
+      "kernel.all.cpu.idle": 1.997,
+      "kernel.all.pressure.io.full.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.io.some.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.cpu.some.avg": {
+        "1 minute": {
+          "val": 0.06,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.memory.full.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      },
+      "kernel.all.pressure.memory.some.avg": {
+        "1 minute": {
+          "val": 0.0,
+          "units": "none"
+        }
+      }
+    }
+    performance_utilization = {"io": {"xvda": 314}, "cpu": 0, "max_io": 314, "memory": 0}
+    performance_profile = PerformanceProfile(
+        system_id=sys_id,
+        state='Idling',
+        operating_system={"name": "RHEL", "major": 8, "minor": 4},
+        performance_record=performance_record,
+        performance_utilization=performance_utilization,
+        report_date=datetime.datetime.utcnow(),
+        number_of_recommendations=1,
+        psi_enabled=False,
+        rule_hit_details=[{
+          "key": "INSTANCE_IDLE",
+          "tags": [],
+          "type": "rule",
+          "links": {
+            "kcs": [],
+            "jira": [
+              "https://issues.redhat.com/browse/CEECBA-5875"
+            ]
+          },
+          "details": {
+            "rhel": "8.4",
+            "type": "rule",
+            "price": 0.0116,
+            "region": "us-east-1",
+            "states": {'idle': ['IDLE']},
+            "error_key": "INSTANCE_IDLE",
+            "candidates": [
+              [
+                "t2.nano",
+                0.0058
+              ]
+            ],
+            "instance_type": "t2.micro",
+            "cloud_provider": "Amazon Web Services"
+          },
+          "rule_id": "ros_instance_evaluation|INSTANCE_IDLE",
+          "component": "telemetry.rules.plugins.ros.ros_instance_evaluation.report",
+          "system_id": "ee0b9978-fe1b-4191-8408-cbadbd47f7a3"
+        }]
+    )
+    db.session.add(performance_profile)
+    db.session.commit()

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -427,9 +427,6 @@ def mock_rbac(json_data, mocker):
     mocker.patch('ros.lib.rbac_interface.query_rbac', return_value=json_data)
 
 
-# This is to test filtering of system groups when RBAC returns one or more group(s) in response.
-# While filtering based on groups we check if group id we get from are there in the System's group field
-# It is expected that we also return systems which are in no groups
 def test_systems_rbac_returns_groups_including_example_group(
         auth_token,
         db_setup,
@@ -440,6 +437,9 @@ def test_systems_rbac_returns_groups_including_example_group(
         db_create_performance_profile,
         create_performance_profiles,
         mocker):
+    """This is to test filtering of system groups when RBAC returns one or more group(s) in response.
+    While filtering based on groups we check if group id we get from are there in the System's group field
+    It is expected that we also return systems which are in no groups"""
     with app.test_client() as client:
         mock_enable_rbac(mocker)
         mock_rbac(get_rbac_mock_file("mock_rbac_returns_groups_including_example_group.json"), mocker)
@@ -449,9 +449,6 @@ def test_systems_rbac_returns_groups_including_example_group(
         assert response.json["data"][0]["groups"][0]["name"] == "example-group"
 
 
-# This is to test filtering of system groups when RBAC returns no groups in response however group.id is present.
-# This is the situation when user has no groups created however groups as features in enabled from inventory
-# In this case we can only return the systems which are not included in any of the groups
 def test_systems_rbac_returns_emtpy_group(
         auth_token,
         db_setup,
@@ -462,6 +459,9 @@ def test_systems_rbac_returns_emtpy_group(
         db_create_performance_profile,
         create_performance_profiles,
         mocker):
+    """This is to test filtering of system groups when RBAC returns no groups in response however group.id is present.
+    This is the situation when user has no groups created however groups as features in enabled from inventory
+    In this case we can only return the systems which are not included in any of the groups"""
     with app.test_client() as client:
         mock_enable_rbac(mocker)
         mock_rbac(get_rbac_mock_file("mock_rbac_returns_emtpy_group.json"), mocker)
@@ -471,9 +471,6 @@ def test_systems_rbac_returns_emtpy_group(
         assert response.json["data"][0]["groups"] == []
 
 
-# This is to test filtering of system groups when RBAC does not return group.id at all.
-# This is the use case where for some reason RBAC does not have group.id included(i.e inventory groups disabled)
-# In this case we return all the systems because we can't find groups as feature enabled
 def test_systems_mock_rbac_returns_no_groups(
         auth_token,
         db_setup,
@@ -484,6 +481,9 @@ def test_systems_mock_rbac_returns_no_groups(
         db_create_performance_profile,
         create_performance_profiles,
         mocker):
+    """This is to test filtering of system groups when RBAC does not return group.id at all.
+    This is the use case where for some reason RBAC does not have group.id included(i.e inventory groups disabled)
+    In this case we return all the systems because we can't find groups as feature enabled"""
     with app.test_client() as client:
         mock_enable_rbac(mocker)
         mock_rbac(get_rbac_mock_file("mock_rbac_returns_no_groups.json"), mocker)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -427,6 +427,9 @@ def mock_rbac(json_data, mocker):
     mocker.patch('ros.lib.rbac_interface.query_rbac', return_value=json_data)
 
 
+# This is to test filtering of system groups when RBAC returns one or more group(s) in response.
+# While filtering based on groups we check if group id we get from are there in the System's group field
+# It is expected that we also return systems which are in no groups
 def test_systems_rbac_returns_groups_including_example_group(
         auth_token,
         db_setup,
@@ -446,6 +449,9 @@ def test_systems_rbac_returns_groups_including_example_group(
         assert response.json["data"][0]["groups"][0]["name"] == "example-group"
 
 
+# This is to test filtering of system groups when RBAC returns no groups in response however group.id is present.
+# This is the situation when user has no groups created however groups as features in enabled from inventory
+# In this case we can only return the systems which are not included in any of the groups
 def test_systems_rbac_returns_emtpy_group(
         auth_token,
         db_setup,
@@ -465,6 +471,9 @@ def test_systems_rbac_returns_emtpy_group(
         assert response.json["data"][0]["groups"] == []
 
 
+# This is to test filtering of system groups when RBAC does not return group.id at all.
+# This is the use case where for some reason RBAC does not have group.id included(i.e inventory groups disabled)
+# In this case we return all the systems because we can't find groups as feature enabled
 def test_systems_mock_rbac_returns_no_groups(
         auth_token,
         db_setup,


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The RBAC now returns groups to which user has access to. The System and dependent objects should be gated as per the group details.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
