### PR TITLE
Don't use pmsocks in pcp config

### DIFF
--- a/ansible-playbooks/ros_install_and_set_up.yml
+++ b/ansible-playbooks/ros_install_and_set_up.yml
@@ -34,7 +34,7 @@
       lineinfile:
         dest: /etc/pcp/pmlogger/control.d/local
         regexp: ".*config.ros.*"
-        line: "LOCALHOSTNAME	n   y	PCP_LOG_DIR/pmlogger/ros	-r -T24h10m -c config.ros -v 100Mb"
+        line: "LOCALHOSTNAME	n   n	PCP_LOG_DIR/pmlogger/ros	-r -T24h10m -c config.ros -v 100Mb"
         create: yes
 
     - name: Create pcp configuration file for ROS


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The pmlogger is using pmsocks which is needed when monitoring the systems protected by firewall. As this is local configuration this is not required, so removing this unnecessary option.

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
