### PR TITLE
Update build deploy scripts.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -5,6 +5,7 @@ set -exv
 IMAGE_NAME="quay.io/cloudservices/ros-backend"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 ADDITIONAL_TAGS="qa latest"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -23,7 +24,13 @@ docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOK
 docker --config="$DOCKER_CONF" build -t "${IMAGE_NAME}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${IMAGE_TAG}"
 
-for ADDITIONAL_TAG in $ADDITIONAL_TAGS; do
-    docker --config="$DOCKER_CONF" tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${ADDITIONAL_TAG}"
-    docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${ADDITIONAL_TAG}"
-done
+
+if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
+    docker --config="$DOCKER_CONF" tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${SECURITY_COMPLIANCE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${SECURITY_COMPLIANCE_TAG}"
+else
+    for ADDITIONAL_TAG in $ADDITIONAL_TAGS; do
+        docker --config="$DOCKER_CONF" tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${ADDITIONAL_TAG}"
+        docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${ADDITIONAL_TAG}"
+    done
+fi


### PR DESCRIPTION
### Overview
This PR updates the 'Security-Compliance Tag' Naming Convention within the 'build_deploy.sh' to make it easier to identify the Git Commit the image is based on.

Example:

OLD: `sc-20230916`
NEW: `sc-20230916-83f605f`