### PR TITLE
Refs #RHIROS-1312 - handle inventory and hosts admin

### DIFF
--- a/ros/api/common/add_group_filter.py
+++ b/ros/api/common/add_group_filter.py
@@ -8,6 +8,9 @@ logger = get_logger(__name__)
 
 
 def group_filtered_query(query):
+    if able_to_access_all_systems():
+        return query
+
     total_groups_from_request = get_host_groups()
     len_of_total_groups = len(total_groups_from_request)
     no_none_groups = [grp for grp in total_groups_from_request if grp is not None]
@@ -29,5 +32,15 @@ def get_host_groups():
     try:
         host_groups = [gid for gid in request.host_groups]
     except AttributeError as e:
-        logger.debug(f"Can't parse the host groups, inventory groups feature is not available?: {e}")
+        logger.debug(f"Can't parse the host_groups, setting host_groups attr to default empty array([])!: {e}")
     return host_groups
+
+
+def able_to_access_all_systems():
+    access_all_systems = False
+    try:
+        access_all_systems = request.able_to_access_all_systems
+    except AttributeError as e:
+        logger.debug("Can't parse the able_to_access_all_systems,"
+                     f"setting able_to_access_all_systems attr to default False value!: {e}")
+    return access_all_systems

--- a/ros/lib/rbac_interface.py
+++ b/ros/lib/rbac_interface.py
@@ -158,7 +158,7 @@ def set_host_groups(rbac_response):
         return
 
     role_list = rbac_response['data']
-    host_groups = []
+    host_groups = set()
     able_to_access_all_systems = False
     for role in role_list:
         if 'permission' not in role:
@@ -201,7 +201,7 @@ def set_host_groups(rbac_response):
                 continue
             # Finally, we have the right key: add them to our list
             # The host_groups may have duplicate group_ids
-            host_groups.extend(value)
+            host_groups.update(value)
 
     # If we found any host groups at the end of that, store them
     if host_groups:

--- a/tests/data_files/mock_rbac_returns_inventory_hosts_read_without_groups.json
+++ b/tests/data_files/mock_rbac_returns_inventory_hosts_read_without_groups.json
@@ -1,0 +1,53 @@
+{
+  "meta": {
+    "count": 5,
+    "limit": 1000,
+    "offset": 0
+  },
+  "links": {
+
+    "first": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0",
+    "next": null,
+    "previous": null,
+    "last": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0"
+  },
+  "data": [
+    {
+      "resourceDefinitions": [],
+      "permission": "ros:*:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "value": [
+              "12345678-fe1b-4191-8408-cbadbd47f7a3"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:groups:read"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:hosts:read"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "_comment": "The test-group id",
+            "value": [
+              "abcdefgh-d97e-4ed0-9095-ef07d73b4839"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:hosts:read"
+    }
+  ]
+}

--- a/tests/data_files/mock_rbac_returns_inventory_hosts_star_without_groups.json
+++ b/tests/data_files/mock_rbac_returns_inventory_hosts_star_without_groups.json
@@ -1,0 +1,53 @@
+{
+  "meta": {
+    "count": 5,
+    "limit": 1000,
+    "offset": 0
+  },
+  "links": {
+
+    "first": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0",
+    "next": null,
+    "previous": null,
+    "last": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0"
+  },
+  "data": [
+    {
+      "resourceDefinitions": [],
+      "permission": "ros:*:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "value": [
+              "12345678-fe1b-4191-8408-cbadbd47f7a3"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:groups:read"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:hosts:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "_comment": "The test-group id",
+            "value": [
+              "abcdefgh-d97e-4ed0-9095-ef07d73b4839"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:hosts:read"
+    }
+  ]
+}

--- a/tests/data_files/mock_rbac_returns_inventory_star_read_without_groups.json
+++ b/tests/data_files/mock_rbac_returns_inventory_star_read_without_groups.json
@@ -1,0 +1,53 @@
+{
+  "meta": {
+    "count": 5,
+    "limit": 1000,
+    "offset": 0
+  },
+  "links": {
+
+    "first": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0",
+    "next": null,
+    "previous": null,
+    "last": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0"
+  },
+  "data": [
+    {
+      "resourceDefinitions": [],
+      "permission": "ros:*:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "value": [
+              "12345678-fe1b-4191-8408-cbadbd47f7a3"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:groups:read"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:*:read"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "_comment": "The test-group id",
+            "value": [
+              "abcdefgh-d97e-4ed0-9095-ef07d73b4839"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:hosts:read"
+    }
+  ]
+}

--- a/tests/data_files/mock_rbac_returns_inventory_star_star_without_groups.json
+++ b/tests/data_files/mock_rbac_returns_inventory_star_star_without_groups.json
@@ -1,0 +1,53 @@
+{
+  "meta": {
+    "count": 5,
+    "limit": 1000,
+    "offset": 0
+  },
+  "links": {
+
+    "first": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0",
+    "next": null,
+    "previous": null,
+    "last": "/api/rbac/v1/access/?application=ros%2Cinventory&limit=1000&offset=0"
+  },
+  "data": [
+    {
+      "resourceDefinitions": [],
+      "permission": "ros:*:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "value": [
+              "12345678-fe1b-4191-8408-cbadbd47f7a3"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:groups:read"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:*:*"
+    },
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "_comment": "The test-group id",
+            "value": [
+              "abcdefgh-d97e-4ed0-9095-ef07d73b4839"
+            ],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:hosts:read"
+    }
+  ]
+}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

When user has 'inventory:hosts:*' or 'inventory:hosts:read' or 'inventory:*:*' or 'inventory:*:read' permissions
and resource definition does not have any groups it means user can see all the systems on ROS

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
