### PR TITLE
Pin flask_caching to <=2.0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1695,4 +1695,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~=3.8"
-content-hash = "7caa6940e9f302e785eea832ef0567a7732279bdacdc6abb131312dd1909f518"
+content-hash = "574e63b42373df90b46de98e1011e79cf1e0f3ce390ffbaa4e7241b2a7827f64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ pyyaml = "*"
 watchtower = ">=1.0.0"
 boto3 = ">=1.16.13"
 botocore = ">=1.19.13"
-flask-caching = "*"
+flask-caching = "^2.0.2"
 flask-unleash = "^2.0.0"
 werkzeug = "<3.0.0"
 


### PR DESCRIPTION
`AttributeError: 'RedisCache' object has no attribute '_client'`
The above is caused by `flask_caching` [v1.11.1](https://github.com/pallets-eco/flask-caching/pull/372) and is fixed in v2.0.0.
To upgrade it to the latest one we need to pin `flask` <v3.0.0 as its latest version (2.0.2) depends on Flask (<3). 
And in turn, we would need to pin `werkzeug` <v3.0.0