### PR TITLE
Refs #RHIROS-1176 - handle condition where description is unavailable

### DIFF
--- a/ros/api/common/instance_types_helper.py
+++ b/ros/api/common/instance_types_helper.py
@@ -1,8 +1,6 @@
 from ros.lib.aws_instance_types import INSTANCE_TYPES
-from ros.extensions import cache
 
 
-@cache.cached(timeout=0)
 def instance_types_desc_dict():
     instance_and_descriptions = {}
     for instance, info in INSTANCE_TYPES.items():

--- a/ros/api/v1/suggested_instance_types.py
+++ b/ros/api/v1/suggested_instance_types.py
@@ -19,6 +19,9 @@ from ros.api.common.pagination import (
 )
 from ros.api.common.instance_types_helper import instance_types_desc_dict
 from ros.api.common.utils import sorting_order
+from ros.lib.config import get_logger
+
+LOG = get_logger(__name__)
 
 
 def non_null_suggested_instance_types():
@@ -71,8 +74,12 @@ class SuggestedInstanceTypes(Resource):
         for row in query_result:
             # FIXME: As of now we only support AWS cloud, so statically adding it to the dict. Fix this code block
             #  upon supporting multiple clouds.
-            record = {'instance_type': row.top_candidate, 'cloud_provider': 'AWS', 'system_count': row.system_count,
-                      'description': instance_types_desc_dict()[row.top_candidate]}
+            record = {'instance_type': row.top_candidate, 'cloud_provider': 'AWS', 'system_count': row.system_count}
+            try:
+                record['description'] = instance_types_desc_dict()[row.top_candidate]
+            except KeyError:
+                LOG.info(f"Unable to get the description for {row.top_candidate}! "
+                         f"Looks like lib/aws_instance_types.py is stale!")
             suggested_instance_types.append(record)
         return build_paginated_system_list_response(limit, offset, suggested_instance_types, count)
 


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

1. It may happen that description is not available for instance_type, hence in that condition we would return null description but api call should succeed
2. The cache is not working for the method, if I update the file then its not reflecting the change. I tried with multiple combinations and hence caching has been removed for instance_types_desc_dict()

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
