### PR TITLE
remove unnecessary logging

### DIFF
--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -147,10 +147,6 @@ class InventoryEventsConsumer:
                         f"{self.prefix} - Refreshed system {system.inventory_id} ({system.id}) "
                         f"belonging to account: {account.account} ({account.id}) and org_id: {account.org_id}"
                     )
-                else:
-                    LOG.info(
-                        f"{self.prefix} - System {system_fields.get('inventory_id')} does not exist in the database"
-                    )
             else:
                 try:
                     account = get_or_create(


### PR DESCRIPTION
## PR Title :boom:

~1lakh vs ~15k log statements.
In my opinion, we can avoid this unnecessary logging.
For successful update event, if system exists, it prints log info at the end. In case of API update request where  system doesn't exist in ROS and reported by User. It is still possible to come to the conclusion.
 
![Screenshot from 2023-12-04 14-24-08](https://github.com/RedHatInsights/ros-backend/assets/6470528/39d92c7b-31f1-4d1e-8772-b8f2d71329ee)
![Screenshot from 2023-12-04 14-25-14](https://github.com/RedHatInsights/ros-backend/assets/6470528/ed4f8e61-76ac-4543-abfa-a562c8ef2d87)

Thoughts?


Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
