### PR TITLE
Fixes #RHINENG-5908 - handle updated platform_metadata dict

### DIFF
--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -350,8 +350,18 @@ def system_allowed_in_ros(msg, reporter):
         # https://consoledot.pages.redhat.com/docs/dev/services/inventory.html#_updated_event
         if (
                 msg.get('type') == 'updated'
-                and msg.get('platform_metadata') is None
+                and is_platform_metadata_empty(msg)
         ):
             return is_valid_cloud_provider(cloud_provider)
         is_ros = msg["platform_metadata"].get("is_ros")
     return validate_ros_payload(is_ros, cloud_provider, operating_system)
+
+
+def is_platform_metadata_empty(msg):
+    if msg.get("platform_metadata") is None or \
+            (isinstance(msg.get("platform_metadata"), dict) and
+             len(msg.get("platform_metadata")) < 1 and
+             "b64_identity" in msg.get("platform_metadata")):
+        return True
+
+    return False

--- a/ros/lib/utils.py
+++ b/ros/lib/utils.py
@@ -350,17 +350,17 @@ def system_allowed_in_ros(msg, reporter):
         # https://consoledot.pages.redhat.com/docs/dev/services/inventory.html#_updated_event
         if (
                 msg.get('type') == 'updated'
-                and is_platform_metadata_empty(msg)
+                and is_platform_metadata_check_pass(msg)
         ):
             return is_valid_cloud_provider(cloud_provider)
         is_ros = msg["platform_metadata"].get("is_ros")
     return validate_ros_payload(is_ros, cloud_provider, operating_system)
 
 
-def is_platform_metadata_empty(msg):
+def is_platform_metadata_check_pass(msg):
     if msg.get("platform_metadata") is None or \
             (isinstance(msg.get("platform_metadata"), dict) and
-             len(msg.get("platform_metadata")) < 1 and
+             len(msg.get("platform_metadata")) <= 1 and
              "b64_identity" in msg.get("platform_metadata")):
         return True
 

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -2,7 +2,7 @@ import json
 from ros.lib import consume
 from ros.lib.app import app
 from ros.extensions import db
-from ros.lib.utils import get_or_create, system_allowed_in_ros, update_system_record
+from ros.lib.utils import get_or_create, system_allowed_in_ros, update_system_record, is_platform_metadata_empty
 from confluent_kafka import KafkaException
 from ros.lib.models import RhAccount, System
 from ros.lib.config import INVENTORY_EVENTS_TOPIC, METRICS_PORT, get_logger
@@ -123,10 +123,7 @@ class InventoryEventsConsumer:
         host = msg['host']
         with app.app_context():
             # 'platform_metadata' field not included when the host is updated via the API.
-            if (
-                    msg.get('type') == 'updated'
-                    and msg.get("platform_metadata") is None
-            ):
+            if (msg.get('type') == 'updated' and is_platform_metadata_empty(msg)):
                 system_fields = {
                     "inventory_id": host['id'],
                     "display_name": host['display_name'],

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -2,7 +2,7 @@ import json
 from ros.lib import consume
 from ros.lib.app import app
 from ros.extensions import db
-from ros.lib.utils import get_or_create, system_allowed_in_ros, update_system_record, is_platform_metadata_empty
+from ros.lib.utils import get_or_create, system_allowed_in_ros, update_system_record, is_platform_metadata_check_pass
 from confluent_kafka import KafkaException
 from ros.lib.models import RhAccount, System
 from ros.lib.config import INVENTORY_EVENTS_TOPIC, METRICS_PORT, get_logger
@@ -123,7 +123,7 @@ class InventoryEventsConsumer:
         host = msg['host']
         with app.app_context():
             # 'platform_metadata' field not included when the host is updated via the API.
-            if (msg.get('type') == 'updated' and is_platform_metadata_empty(msg)):
+            if (msg.get('type') == 'updated' and is_platform_metadata_check_pass(msg)):
                 system_fields = {
                     "inventory_id": host['id'],
                     "display_name": host['display_name'],


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The platform_metadata use to be empty if there is nothing in it, however now when its empty it at least has "bs64_identity". This breaks ROS use cases as we use to depend on "platform_metadata" being None!
## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.
