### PR TITLE
RHINENG-15954 upgrade action/cache to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         python-version: 3.11
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/build_with_latest_direct_deps.yml
+++ b/.github/workflows/build_with_latest_direct_deps.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         python-version: 3.11
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/build_with_latest_indirect_deps.yml
+++ b/.github/workflows/build_with_latest_indirect_deps.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         python-version: 3.11
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
     
     - name: Cache pip packages
-      uses: actions/cache@v3.2.2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

`action/cache` versions v1 and v2 are deprecating. We need to upgrade it to v4.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

References: [https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)