### PR TITLE
Update the way ENABLE_RBAC is patched

### DIFF
--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -431,7 +431,7 @@ def get_rbac_mock_file(filename):
 
 
 def mock_enable_rbac(mocker):
-    mocker.patch('ros.lib.rbac_interface.ENABLE_RBAC', return_value=True)
+    mocker.patch('ros.lib.rbac_interface.ENABLE_RBAC', new_callable=lambda: True)
 
 
 def mock_rbac(json_data, mocker):


### PR DESCRIPTION
While working on the PoC for kessel, i tried to disable RBAC by having a similar method i.e.

```
def mock_disable_rbac(mocker):
    mocker.patch('ros.lib.rbac_interface.ENABLE_RBAC', return_value=False)
```

This did not set the variable and I could confirm in the debugger that bool(ENABLE_RBAC) was still true, but ENABLE_RBAC() was returning false.

After a bit of reading this syntax made bool(ENABLE_RBAC) to resolve to false

This PR doesn't really change any behavior as `ENABLE_RBAC` was set to `True` anyway, but the syntax seems misleading.

## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Update the mocking method for ENABLE_RBAC to correctly set the boolean value in tests

Enhancements:
- Modified the mock_enable_rbac function to use new_callable to ensure correct boolean resolution

Tests:
- Updated the test mocking approach for ENABLE_RBAC to resolve boolean context correctly