### PR TITLE
RHINENG-18290 fix cache key error on engine processor

### DIFF
--- a/ros/lib/app.py
+++ b/ros/lib/app.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from ros.extensions import db
+from ros.extensions import db, cache
 from .config import DB_URI, DB_POOL_SIZE, DB_MAX_OVERFLOW
 from flask import request
 from .rbac_interface import ensure_has_permission
@@ -21,6 +21,7 @@ def create_app():
     db.init_app(app)
     migrate = Migrate()
     migrate.init_app(app, db)
+    cache.init_app(app)
     return app
 
 

--- a/ros/processor/insights_engine_consumer.py
+++ b/ros/processor/insights_engine_consumer.py
@@ -272,7 +272,6 @@ class InsightsEngineConsumer:
 
 if __name__ == "__main__":
     start_http_server(int(METRICS_PORT))
-    cache.init_app(app)
     commence_cw_log_streaming('ros-processor')
     processor = InsightsEngineConsumer()
     processor.run()

--- a/ros/processor/inventory_events_consumer.py
+++ b/ros/processor/inventory_events_consumer.py
@@ -231,7 +231,6 @@ class InventoryEventsConsumer:
 
 if __name__ == "__main__":
     start_http_server(int(METRICS_PORT))
-    cache.init_app(app)
     commence_cw_log_streaming('ros-processor')
     processor = InventoryEventsConsumer()
     processor.run()


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Resolves [RHINENG-18290](https://issues.redhat.com/browse/RHINENG-18290)

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Bug Fixes:
- Centralize cache initialization in create_app and remove redundant cache.init_app calls in insights_engine_consumer and inventory_events_consumer to prevent cache key errors.