### PR TITLE
RHINENG-19216 remove unused unleash code

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -72,8 +72,6 @@ objects:
                 name: ${UNLEASH_SECRET_NAME}
                 key: CLIENT_ACCESS_TOKEN
                 optional: true
-          - name: BYPASS_UNLEASH
-            value: ${BYPASS_UNLEASH}
 
     - name: inventory-events-processor
       replicas: ${{INVENTORY_PROCESSOR_REPLICA_COUNT}}
@@ -123,8 +121,6 @@ objects:
                 name: ${UNLEASH_SECRET_NAME}
                 key: CLIENT_ACCESS_TOKEN
                 optional: true
-          - name: BYPASS_UNLEASH
-            value: ${BYPASS_UNLEASH}
 
     - name: engine-result-processor
       replicas: ${{ENGINE_PROCESSOR_REPLICA_COUNT}}
@@ -174,8 +170,6 @@ objects:
                 name: ${UNLEASH_SECRET_NAME}
                 key: CLIENT_ACCESS_TOKEN
                 optional: true
-          - name: BYPASS_UNLEASH
-            value: ${BYPASS_UNLEASH}
 
     - name: garbage-collector-processor
       replicas: ${{GARBAGE_COLLECTOR_REPLICA_COUNT}}
@@ -229,8 +223,6 @@ objects:
                 name: ${UNLEASH_SECRET_NAME}
                 key: CLIENT_ACCESS_TOKEN
                 optional: true
-          - name: BYPASS_UNLEASH
-            value: ${BYPASS_UNLEASH}
 
     database:
       name: ros
@@ -359,6 +351,3 @@ parameters:
   value: bypass
 - description: Unleash API url
   name: UNLEASH_URL
-- description: disable Unleash (feature flags), defaulting to fallback values
-  name: BYPASS_UNLEASH
-  value: 'false'

--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -76,8 +76,6 @@ if CLOWDER_ENABLED:
 
     # Feature flags
     unleash = LoadedConfig.featureFlags
-    BYPASS_UNLEASH = True if os.getenv("BYPASS_UNLEASH", default="False").lower() in ["true", "t", "yes",
-                                                                                      "y"] else False
     UNLEASH_CACHE_DIR = os.getenv("UNLEASH_CACHE_DIR", "/tmp/.unleashcache")
     UNLEASH_TOKEN = unleash.clientAccessToken if unleash else None
     UNLEASH_URL = f"{unleash.hostname}:{unleash.port}/api" if unleash else None
@@ -111,7 +109,6 @@ else:
     NOTIFICATIONS_TOPIC = os.getenv("NOTIFICATIONS_TOPIC", "platform.notifications.ingress")
     ROS_EVENTS_TOPIC = os.getenv("ROS_EVENTS_TOPIC", "ros.events")
     TLS_CA_PATH = os.getenv("TLS_CA_PATH", None)
-    BYPASS_UNLEASH = True
     CW_ENABLED = str_to_bool(os.getenv('CW_ENABLED', 'False'))  # CloudWatch/Kibana Logging
     if CW_ENABLED is True:
         AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", None)


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Resolves - [RHINENG-19216](https://issues.redhat.com/browse/RHINENG-19216)

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [X] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Remove obsolete Unleash feature-bypass code by stripping related environment variables, config handling, deployment parameters, and test mocks.

Enhancements:
- Eliminate BYPASS_UNLEASH environment variable loading and flag fallback logic from application configuration
- Prune Unleash bypass code paths and constants from ros/lib/config.py

Deployment:
- Remove BYPASS_UNLEASH parameter definitions and env var references from clowdapp.yaml

Tests:
- Delete mock_unleash_hbi_flag_enabled function and its invocations from API endpoint tests