### PR TITLE
Fixes #RHINENG-19057 - Singleton grpc and stub

### DIFF
--- a/ros/lib/kessel/singleton_grpc.py
+++ b/ros/lib/kessel/singleton_grpc.py
@@ -1,0 +1,24 @@
+import grpc
+from ros.lib.config import get_logger
+from kessel.inventory.v1beta2 import inventory_service_pb2_grpc
+
+LOG = get_logger(__name__)
+
+# Singleton storage
+_GRPC_CHANNEL = None
+_GRPC_STUB = None
+
+
+def get_kessel_stub(host):
+    global _GRPC_CHANNEL, _GRPC_STUB
+
+    if _GRPC_STUB is None:
+        try:
+            _GRPC_CHANNEL = grpc.insecure_channel(host)
+        except grpc.RpcError as err:
+            LOG.error(f"Failed to establish grpc connection to {host}: {err}")
+            raise
+
+        _GRPC_STUB = inventory_service_pb2_grpc.KesselInventoryServiceStub(_GRPC_CHANNEL)
+
+    return _GRPC_STUB


### PR DESCRIPTION
## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Use a singleton pattern for gRPC channel and stub to reuse connections and simplify KesselClient initialization

Enhancements:
- Add singleton_grpc module with get_kessel_stub to lazily initialize and return a single gRPC channel and stub
- Refactor KesselClient to use get_kessel_stub instead of creating a new channel and stub in its constructor