### PR TITLE
Fix docker-compose Kafka startup issues and networking docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ docker-compose up ros-processor ros-api
 ```
 
 ### On host machine
-In order to properly run the application from the host machine, you need to have modified your `/etc/hosts` file. Check the
-README.md file in scripts directory.
+In order to properly run the application from the host machine, you may optionally modify your `/etc/hosts` file for convenience. 
+Check the README.md file in scripts directory for details and important networking considerations.
 
 #### Initialize the database
 Run the following commands to execute the db migration scripts.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,12 +3,17 @@ Below are the instructions to setup ROS development environment
 
 ## Setup
 
-1. If you want to access the containers from host machine, update /etc/hosts
+1. **Optional**: To access services from your host machine, you can either:
+   - Use the mapped ports: `localhost:9092` (Kafka), `localhost:9000` (Minio)
+   - Or add entries to `/etc/hosts` for convenience (NOT recommended as it breaks container networking):
 
-```
-127.0.0.1       kafka
-127.0.0.1       minio
-```
+   ```
+   # WARNING: Adding these entries will break container-to-container communication
+   # Only use if you specifically need to access services by name from the host
+   # Remove these entries if containers fail to connect to each other
+   127.0.0.1       kafka
+   127.0.0.1       minio
+   ```
 
 3. Clone ros-backend repository.
 ```bash

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ZOOKEEPER_CLIENT_PORT=32181
       - ZOOKEEPER_SERVER_ID=1
   kafka:
-    image: confluentinc/cp-kafka
+    image: confluentinc/cp-kafka:7.5.9
     ports:
       - 29092:29092
       - 9092:9092
@@ -25,7 +25,7 @@ services:
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
   # Below container is to implement workaround for creating required topics.
   kafka-create-topics:
-    image: confluentinc/cp-kafka
+    image: confluentinc/cp-kafka:7.5.9
     ports:
       - 7777:29092
     command: "bash -c 'echo Waiting for Kafka to be ready... && \


### PR DESCRIPTION
 ## Why do we need this change? :thought_balloon:

 Fix two separate issues that prevent successful local development setup:
  1. **Kafka version compatibility**: The latest Kafka images require `KRaft` mode configuration, but this setup uses Zookeeper. This causes startup failures with the error `KAFKA_PROCESS_ROLES is required.`
  2. **Networking documentation**: The README instructions to add /etc/hosts entries can break container-to-container communication, causing `kafka-create-topics` to fail with DNS resolution errors.

  ## Documentation update? :memo:

  - [x] Yes
  - [ ] No

  ## Security Checklist :lock:

  Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

  ## :guardsman: Checklist :dart:

  - [x] Bugfix
  - [ ] New Feature
  - [ ] Refactor
  - [ ] Unittests Added
  - [ ] DRY code
  - [ ] Dependency Added
  - [ ] DB Migration Added

  ## Additional :mega:

  **Errors resolved:**
  - `KAFKA_PROCESS_ROLES is required. Command [/usr/local/bin/dub ensure KAFKA_PROCESS_ROLES] FAILED !`
  - `Connection to node -1 (kafka/127.0.0.1:29092) could not be established. Broker may not be available.`

  **Testing:** Verified that containers start successfully and kafka-create-topics completes without errors after applying these changes.