### PR TITLE
RHINENG-15102 handle api events on Suggestions Engine

### DIFF
--- a/ros/processor/report_processor_event_producer.py
+++ b/ros/processor/report_processor_event_producer.py
@@ -24,7 +24,7 @@ def no_pcp_raw_payload(payload):
 
 
 def produce_report_processor_event(payload, producer):
-    request_id = payload.get('platform_metadata').get('request_id')
+    request_id = payload.get('metadata').get('request_id')
     host = payload.get('host')
     tailored_payload = no_pcp_raw_payload(payload)
     bytes_ = json.dumps(tailored_payload).encode('utf-8')

--- a/ros/processor/report_processor_event_producer.py
+++ b/ros/processor/report_processor_event_producer.py
@@ -3,7 +3,7 @@ from ros.lib.config import ROS_EVENTS_TOPIC
 from ros.lib.produce import delivery_report
 
 
-def no_pcp_raw_payload(payload):
+def api_and_no_pcp_raw_payload(payload):
     host = payload.get('host')
 
     payload = {
@@ -26,7 +26,7 @@ def no_pcp_raw_payload(payload):
 def produce_report_processor_event(payload, producer):
     request_id = payload.get('metadata').get('request_id')
     host = payload.get('host')
-    tailored_payload = no_pcp_raw_payload(payload)
+    tailored_payload = api_and_no_pcp_raw_payload(payload)
     bytes_ = json.dumps(tailored_payload).encode('utf-8')
     producer.produce(
         topic=ROS_EVENTS_TOPIC,

--- a/ros/processor/suggestions_engine.py
+++ b/ros/processor/suggestions_engine.py
@@ -221,7 +221,7 @@ class SuggestionsEngine:
     def handle_api_event(self, payload):
         host = payload.get('host')
         logging.debug(
-            f"{self.service} - {self.event} - Triggering an event for system {host.get('id')}"
+            f"{self.service} - {self.event} - Triggering an event for system {host.get('id')}, updated via API"
         )
         self.consumer.commit()
         produce_report_processor_event(payload, self.producer)

--- a/ros/processor/suggestions_engine.py
+++ b/ros/processor/suggestions_engine.py
@@ -218,6 +218,27 @@ class SuggestionsEngine:
                 for r in rules:
                     print(rules_execution_output[r])
 
+    def handle_api_event(self, payload):
+        host = payload.get('host')
+        logging.debug(
+            f"{self.service} - {self.event} - Triggering an event for system {host.get('id')}"
+        )
+        self.consumer.commit()
+        produce_report_processor_event(payload, self.producer)
+        return
+
+    def process_message(self, message):
+        payload = json.loads(message.value().decode('utf-8'))
+        event_type = payload['type']
+
+        headers = dict(message.headers() or [])
+        producer = headers.get('producer', b'').decode('utf-8')
+
+        if event_type == 'updated' and 'host-inventory-service' in producer:
+            self.handle_api_event(payload)
+        elif event_type in ('created', 'updated'):
+            self.handle_create_update(payload)
+
     def run(self):
         logging.info(f"{self.service} - Engine is running. Awaiting msgs.")
         try:
@@ -227,12 +248,7 @@ class SuggestionsEngine:
                     continue
 
                 try:
-                    payload = json.loads(message.value().decode('utf-8'))
-                    event_type = payload['type']
-
-                    if 'created' == event_type or 'updated' == event_type:
-                        self.handle_create_update(payload)
-
+                    self.process_message(message)
                 except json.JSONDecodeError as error:
                     logging.error(f"{self.service} - {self.event} - Failed to decode message: {error}")
                 except Exception as error:

--- a/tests/test_suggestions_engine.py
+++ b/tests/test_suggestions_engine.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, Mock
 import json
 
 from ros.processor.suggestions_engine import SuggestionsEngine
-from ros.processor.report_processor_event_producer import no_pcp_raw_payload
+from ros.processor.report_processor_event_producer import api_and_no_pcp_raw_payload
 
 
 class TestSuggestionsEngine(unittest.TestCase):
@@ -164,11 +164,11 @@ class TestNoPcpRawPayload(unittest.TestCase):
             "cloud_provider": "aws"
         }
 
-        self.assertEqual(no_pcp_raw_payload(input_payload), expected_output)
+        self.assertEqual(api_and_no_pcp_raw_payload(input_payload), expected_output)
 
     def test_missing_host(self):
         with self.assertRaises(AttributeError):
-            no_pcp_raw_payload({
+            api_and_no_pcp_raw_payload({
                 "type": "created",
                 "platform_metadata": {"request_id": "a1b2c3"},
                 "host": None
@@ -211,7 +211,7 @@ class TestNoPcpRawPayload(unittest.TestCase):
             "cloud_provider": "aws",
         }
 
-        self.assertEqual(no_pcp_raw_payload(input_payload), expected_output)
+        self.assertEqual(api_and_no_pcp_raw_payload(input_payload), expected_output)
 
 
 class TestAPIEvent(unittest.TestCase):


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Resolves - [RHINENG-15102](https://issues.redhat.com/browse/RHINENG-15102)

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [X] New Feature
- [ ] Refactor
- [X] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Handle API events in SuggestionsEngine by adding process_message and handle_api_event to route 'updated' events from host-inventory-service, refactor run loop accordingly, fix metadata key in report processor event producer, and cover changes with unit tests

New Features:
- Add handle_api_event method to process updated events from host-inventory-service and emit report processor events

Bug Fixes:
- Correct request_id lookup in produce_report_processor_event to use 'metadata' instead of 'platform_metadata'

Enhancements:
- Extract message parsing and routing into a new process_message method
- Refactor SuggestionsEngine.run to delegate to process_message for consistent event handling

Tests:
- Add unit tests to verify API event routing and fallback to create/update handling