### PR TITLE
Initialize event variable for api event

### DIFF
--- a/ros/processor/suggestions_engine.py
+++ b/ros/processor/suggestions_engine.py
@@ -219,6 +219,7 @@ class SuggestionsEngine:
                     print(rules_execution_output[r])
 
     def handle_api_event(self, payload):
+        self.event = "Update event"
         host = payload.get('host')
         logging.debug(
             f"{self.service} - {self.event} - Triggering an event for system {host.get('id')}, updated via API"


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Logging `None` in case of API event handling. We should add `Update` as the event type, as we only get update events from API.

```
$ python -m ros.processor.suggestions_engine
2025-08-25 16:05:28,828 - INFO  - run - SUGGESTIONS_ENGINE - Engine is running. Awaiting msgs.
2025-08-25 16:05:37,974 - DEBUG  - handle_api_event - SUGGESTIONS_ENGINE - None - Triggering an event for system 123123, updated via API
2025-08-25 16:05:37,981 - INFO  - delivery_report - Message delivered to ros.events topic for request_id a1b2c3 and system 123123
```

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Bug Fixes:
- Set self.event to "Update event" in handle_api_event to ensure correct event type in logs