### PR TITLE
RHINENG-20267 Implement Kafka consumer for system eraser service

### DIFF
--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -152,6 +152,7 @@ ROS_API_PORT = int(os.getenv("ROS_API_PORT", "8000"))
 CACHE_TIMEOUT_FOR_DELETED_SYSTEM = int(
     os.getenv("CACHE_TIMEOUT_FOR_DELETED_SYSTEM", "86400"))
 CACHE_KEYWORD_FOR_DELETED_SYSTEM = '_del_'
+POLL_TIMEOUT_SECS = 1.0
 
 
 def kafka_auth_config(connection_object=None):


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Resolves [RHINENG-20267](https://issues.redhat.com/browse/RHINENG-20267)

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [X] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Implement a Kafka consumer for the system eraser service that filters and processes delete events from the inventory events topic, logs processing steps and errors, and exposes metrics via a Prometheus HTTP server.

New Features:
- Add SystemEraser class to consume delete events from the inventory events Kafka topic
- Launch Prometheus metrics HTTP server on the configured metrics port