### PR TITLE
Use space separated output of pmlogsummary

### DIFF
--- a/ros/processor/suggestions_engine.py
+++ b/ros/processor/suggestions_engine.py
@@ -76,7 +76,6 @@ class SuggestionsEngine:
 
         pmlogsummary_command = [
             "pmlogsummary",
-            "-F",
             os.path.join(output_dir, ".index")
         ]
 


### PR DESCRIPTION
The -F option is for CSV output format,
however the insights-core parser can only consume
space separated metrics

## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Bug Fixes:
- Remove the -F option from the pmlogsummary invocation to switch from CSV to space-delimited output