### PR TITLE
Fixes on Kessel clowdapp input

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -81,7 +81,7 @@ objects:
           - name: KESSEL_AUTH_ENABLED
             value: ${KESSEL_AUTH_ENABLED}
           - name: KESSEL_AUTH_OIDC_ISSUER
-            value: ${KESSEL_AUTH_OIDC_ISSUER}/protocol/openid-connect/token
+            value: ${KESSEL_AUTH_OIDC_ISSUER}
           - name: KESSEL_INSECURE
             value: ${KESSEL_INSECURE}
           - name: KESSEL_AUTH_CLIENT_ID
@@ -154,7 +154,7 @@ objects:
           - name: KESSEL_AUTH_ENABLED
             value: ${KESSEL_AUTH_ENABLED}
           - name: KESSEL_AUTH_OIDC_ISSUER
-            value: ${KESSEL_AUTH_OIDC_ISSUER}/protocol/openid-connect/token
+            value: ${KESSEL_AUTH_OIDC_ISSUER}
           - name: KESSEL_INSECURE
             value: ${KESSEL_INSECURE}
           - name: KESSEL_AUTH_CLIENT_ID
@@ -228,7 +228,7 @@ objects:
           - name: KESSEL_AUTH_ENABLED
             value: ${KESSEL_AUTH_ENABLED}
           - name: KESSEL_AUTH_OIDC_ISSUER
-            value: ${KESSEL_AUTH_OIDC_ISSUER}/protocol/openid-connect/token
+            value: ${KESSEL_AUTH_OIDC_ISSUER}
           - name: KESSEL_INSECURE
             value: ${KESSEL_INSECURE}
           - name: KESSEL_AUTH_CLIENT_ID
@@ -305,7 +305,7 @@ objects:
           - name: KESSEL_AUTH_ENABLED
             value: ${KESSEL_AUTH_ENABLED}
           - name: KESSEL_AUTH_OIDC_ISSUER
-            value: ${KESSEL_AUTH_OIDC_ISSUER}/protocol/openid-connect/token
+            value: ${KESSEL_AUTH_OIDC_ISSUER}
           - name: KESSEL_INSECURE
             value: ${KESSEL_INSECURE}
           - name: KESSEL_AUTH_CLIENT_ID
@@ -447,10 +447,6 @@ parameters:
   value: kessel-inventory-api:9000
 - name: KESSEL_AUTH_ENABLED
   value: "false"
-- name: KESSEL_AUTH_CLIENT_ID
-  value: ""
-- name: KESSEL_AUTH_CLIENT_SECRET
-  value: ""
 - name: KESSEL_AUTH_OIDC_ISSUER
   value: ""
 - name: KESSEL_INSECURE


### PR DESCRIPTION
- Fixing KESSEL_AUTH_OIDC_ISSUER format Removes path to the token - the discovery will take care of finding it
- Removes the empty KESSEL_AUTH_CLIENT_ID and KESSEL_AUTH_CLIENT_SECRET

## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Normalize Kessel authentication configuration by removing hardcoded token endpoint suffix and eliminating empty credential defaults

Enhancements:
- Remove '/protocol/openid-connect/token' suffix from KESSEL_AUTH_OIDC_ISSUER in clowdapp.yaml service definitions
- Remove empty default parameters for KESSEL_AUTH_CLIENT_ID and KESSEL_AUTH_CLIENT_SECRET