### PR TITLE
updating shared pipeline to latest version

### DIFF
--- a/.tekton/ros-backend-sc-pull-request.yaml
+++ b/.tekton/ros-backend-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.45.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: resource-optimization-sc

--- a/.tekton/ros-backend-sc-push.yaml
+++ b/.tekton/ros-backend-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.45.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: resource-optimization-sc


### PR DESCRIPTION
Updating SC shared pipelines to use latest version

## Summary by Sourcery

CI:
- Point the pipelinesascode 'pipeline' annotation to the raw main branch URL for docker-build-oci-ta.yaml instead of the v1.45.0 tag in both pull-request and push triggers