### PR TITLE
remove org-id-populator job from clowdapp

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -541,40 +541,6 @@ objects:
     testing:
       iqePlugin: ros
 
-    jobs:
-    - name: org-id-populator
-      podSpec:
-        image: quay.io/cloudservices/tenant-utils:latest
-        command:
-          - ./org-id-column-populator
-          - -C
-          - -a
-          - account
-          - -o
-          - org_id
-          - -t
-          - rh_accounts
-          - --ean-translator-addr
-          - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
-          - --prometheus-push-addr
-          - ${PROMETHEUS_PUSHGATEWAY}
-        env:
-          - name: TENANT_TRANSLATOR_HOST
-            value: ${TENANT_TRANSLATOR_HOST}
-          - name: TENANT_TRANSLATOR_PORT
-            value: ${TENANT_TRANSLATOR_PORT}
-          - name: LOG_FORMAT
-            value: ${POPULATOR_LOG_FORMAT}
-          - name: LOG_BATCH_FREQUENCY
-            value: '1s'
-        resources:
-          limits:
-            cpu: 300m
-            memory: 1Gi
-          requests:
-            cpu: 50m
-            memory: 512Mi
-
 parameters:
 - description: Enable rbac needs to be "True" or "False"
   name: ENABLE_RBAC


### PR DESCRIPTION
## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## ROS RHEL GitHub label usage for executing a desired test suite

Select the appropriate GitHub label to control which ROS RHEL backend tests run for this PR (Labels can be added before or after commits are pushed):

**Note:** Changing a Label on a PR with an already-tested commit will not trigger a new test run

**Available ROS RHEL labels:**

- **test-backend-v1:** Run legacy backend tests only
- **test-backend-v2:** Run new backend tests only
- **test-backend-both:** Run both backend tests

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Chores:
- Clean up ClowdApp configuration by deleting the org-id-populator background job definition.