### PR TITLE
RHINENG-25817 use ssl mode from clowder

### DIFF
--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -129,11 +129,10 @@ else:
     UNLEASH_URL = os.getenv("UNLEASH_URL", "http://localhost:3063/api")
 
 DB_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}"\
-         f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-if DB_SSL_CERTPATH:
-    DB_URI += f"?sslmode={DB_SSL_MODE}&sslrootcert={DB_SSL_CERTPATH}"
-elif DB_SSL_MODE != "disable":
-    DB_URI += f"?sslmode={DB_SSL_MODE}"
+         f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"\
+         f"?sslmode={DB_SSL_MODE}"
+if DB_SSL_MODE != "disable" and DB_SSL_CERTPATH:
+    DB_URI += f"&sslrootcert={DB_SSL_CERTPATH}"
 
 DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", '5'))
 DB_MAX_OVERFLOW = int(os.getenv("DB_MAX_OVERFLOW", '10'))

--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -31,7 +31,7 @@ def build_endpoint_url(ep):
 
 LOG = logging.getLogger(__name__)
 CLOWDER_ENABLED = True if os.getenv("CLOWDER_ENABLED", default="False").lower() in ["true", "t", "yes", "y"] else False
-DB_SSL_MODE = "verify-full"
+DB_SSL_MODE = "disable"
 DB_SSL_CERTPATH = None
 
 if CLOWDER_ENABLED:
@@ -45,6 +45,7 @@ if CLOWDER_ENABLED:
     DB_PASSWORD = LoadedConfig.database.password
     DB_HOST = LoadedConfig.database.hostname
     DB_PORT = LoadedConfig.database.port
+    DB_SSL_MODE = LoadedConfig.database.sslMode
     if LoadedConfig.database.rdsCa:
         DB_SSL_CERTPATH = LoadedConfig.rds_ca()
     REDIS_USERNAME = LoadedConfig.inMemoryDb.username
@@ -131,6 +132,8 @@ DB_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}"\
          f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 if DB_SSL_CERTPATH:
     DB_URI += f"?sslmode={DB_SSL_MODE}&sslrootcert={DB_SSL_CERTPATH}"
+elif DB_SSL_MODE != "disable":
+    DB_URI += f"?sslmode={DB_SSL_MODE}"
 
 DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", '5'))
 DB_MAX_OVERFLOW = int(os.getenv("DB_MAX_OVERFLOW", '10'))

--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -129,10 +129,11 @@ else:
     UNLEASH_URL = os.getenv("UNLEASH_URL", "http://localhost:3063/api")
 
 DB_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}"\
-         f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"\
-         f"?sslmode={DB_SSL_MODE}"
-if DB_SSL_MODE != "disable" and DB_SSL_CERTPATH:
-    DB_URI += f"&sslrootcert={DB_SSL_CERTPATH}"
+         f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+if DB_SSL_MODE != "disable":
+    DB_URI += f"?sslmode={DB_SSL_MODE}"
+    if DB_SSL_CERTPATH:
+        DB_URI += f"&sslrootcert={DB_SSL_CERTPATH}"
 
 DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", '5'))
 DB_MAX_OVERFLOW = int(os.getenv("DB_MAX_OVERFLOW", '10'))

--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -132,7 +132,9 @@ DB_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}"\
          f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 if DB_SSL_MODE != "disable":
     DB_URI += f"?sslmode={DB_SSL_MODE}"
-    if DB_SSL_CERTPATH:
+    if DB_SSL_MODE in ("verify-ca", "verify-full"):
+        if not DB_SSL_CERTPATH:
+            raise ValueError(f"sslrootcert is required when sslmode is {DB_SSL_MODE}")
         DB_URI += f"&sslrootcert={DB_SSL_CERTPATH}"
 
 DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", '5'))


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

As a part of [RHINENG-25817](https://redhat.atlassian.net/browse/RHINENG-25817)

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [X] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## ROS RHEL GitHub label usage for executing a desired test suite

Select the appropriate GitHub label to control which ROS RHEL backend tests run for this PR (Labels can be added before or after commits are pushed):

**Note:** Changing a Label on a PR with an already-tested commit will not trigger a new test run

**Available ROS RHEL labels:**

- **test-backend-v1:** Run legacy backend tests only
- **test-backend-v2:** Run new backend tests only
- **test-backend-both:** Run both backend tests

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.


[RHINENG-25817]: https://redhat.atlassian.net/browse/RHINENG-25817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Derive database SSL mode from Clowder configuration when available and append the appropriate sslmode parameter to the database URI when no certificate path is configured.