### PR TITLE
RHINENG-25815 Update PostgreSQL version to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/build_with_latest_direct_deps.yml
+++ b/.github/workflows/build_with_latest_direct_deps.yml
@@ -18,7 +18,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         ports:
           - 15432:5432
         env:

--- a/.github/workflows/build_with_latest_indirect_deps.yml
+++ b/.github/workflows/build_with_latest_indirect_deps.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -527,7 +527,7 @@ objects:
 
     database:
       name: ros
-      version: 13
+      version: 16
     inMemoryDb: true
     kafkaTopics:
       - topicName: platform.inventory.events

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -83,7 +83,7 @@ services:
     depends_on:
     - kafka
   db-ros:
-    image: postgres
+    image: postgres:16
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres
@@ -92,7 +92,7 @@ services:
     ports:
       - "15432:5432"
   db-inventory:
-    image: postgres
+    image: postgres:16
     restart: always
     environment:
       POSTGRES_PASSWORD: insights


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Resolves [RHINENG-25815](https://redhat.atlassian.net/browse/RHINENG-25815). Update the DB version of the files after the migration to ensure consistency.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## ROS RHEL GitHub label usage for executing a desired test suite

Select the appropriate GitHub label to control which ROS RHEL backend tests run for this PR (Labels can be added before or after commits are pushed):

**Note:** Changing a Label on a PR with an already-tested commit will not trigger a new test run

**Available ROS RHEL labels:**

- **test-backend-v1:** Run legacy backend tests only
- **test-backend-v2:** Run new backend tests only
- **test-backend-both:** Run both backend tests

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.


[RHINENG-25815]: https://redhat.atlassian.net/browse/RHINENG-25815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update PostgreSQL version references and supporting CI/infra configuration to use PostgreSQL 16.

Build:
- Update local docker-compose services to run PostgreSQL 16 for ROS and inventory databases.

CI:
- Update GitHub Actions workflows to use PostgreSQL 16 in build and dependency-check jobs.
- Refresh Tekton task bundle digests for security and compliance checks in pull-request and push pipelines.

Deployment:
- Bump ClowdApp database configuration from PostgreSQL 13 to PostgreSQL 16 for the ROS service.