### PR TITLE
fix/RHINENG-26860 Check Kessel before RBAC v1 in check_permission

### DIFF
--- a/ros/lib/check_permission.py
+++ b/ros/lib/check_permission.py
@@ -32,6 +32,22 @@ def check_permission(**kwargs):
             HTTPStatus.BAD_REQUEST, message="Identity not found in request"
         )
 
+    if ENABLE_KESSEL:
+        kessel_response = query_kessel(auth_key)
+        if kessel_response["host_groups"]:
+            host_groups = kessel_response["host_groups"]
+            setattr(request, host_group_attr, host_groups)
+            LOG.info(f"Kessel Enabled - User has host groups {host_groups}")
+        else:
+            abort(
+                HTTPStatus.FORBIDDEN,
+                message='User does not have correct permissions to access the service'
+            )
+
+        # Kessel returns exactly the workspaces we have access to
+        setattr(request, access_all_systems, False)
+        return
+
     if ENABLE_RBAC:
         rbac_response = query_rbac(kwargs["application"], auth_key, kwargs["logger"])
         perms = [perm["permission"] for perm in rbac_response.get("data")]
@@ -50,21 +66,6 @@ def check_permission(**kwargs):
             HTTPStatus.FORBIDDEN,
             message='User does not have correct permissions to access the service'
         )
-
-    if ENABLE_KESSEL and not ENABLE_RBAC:
-        kessel_response = query_kessel(auth_key)
-        if kessel_response["host_groups"]:
-            host_groups = kessel_response["host_groups"]
-            setattr(request, host_group_attr, host_groups)
-            LOG.info(f"Kessel Enabled - User has host groups {host_groups}")
-        else:
-            abort(
-                HTTPStatus.FORBIDDEN,
-                message='User does not have correct permissions to access the service'
-            )
-
-        # Set admin to false - Kessel will return exactly the workspaces we have access to
-        setattr(request, access_all_systems, False)
 
 
 def _is_mgmt_url(path):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -714,6 +714,34 @@ def test_kessel_workspaces(
         assert response.json["data"][1]["groups"][0]["name"] == "test-group"
 
 
+def test_kessel_takes_priority_over_rbac(
+        auth_token,
+        db_setup,
+        db_create_account,
+        db_create_system,
+        system_with_example_group,
+        system_with_test_group,
+        system_with_foo_group,
+        db_create_performance_profile,
+        create_performance_profiles,
+        mocker):
+    with app.test_client() as client:
+        mock_enable_rbac(mocker)
+        mock_enable_kessel(mocker)
+        rbac_spy = mocker.patch('ros.lib.check_permission.query_rbac')
+        mock_kessel({
+            "ros_can_read": True,
+            "host_groups": [
+                "155860d5-648c-4529-847a-690cbf198934",
+                "abcdefgh-d97e-4ed0-9095-ef07d73b4839",
+                "d4e2fc0f-617d-49d5-8d1b-acbb423f0fbe",
+            ]
+        }, mocker)
+        response = client.get('/api/ros/v1/systems', headers={"x-rh-identity": auth_token})
+        assert response.status_code == 200
+        rbac_spy.assert_not_called()
+
+
 @pytest.mark.no_suggestions
 def test_no_suggestions_when_system_is_optimized(
         auth_token,


### PR DESCRIPTION
## Fixes RHINENG-26860 - Check Kessel before RBAC v1 in check_permission

When both `ENABLE_KESSEL` and `ENABLE_RBAC` are true, the Kessel path now takes priority. Previously v1 RBAC ran first, making the Kessel branch unreachable. This broke orgs with v2 access management enabled, since RBAC v1/access returns HTTP 400 for those orgs, and likely means Kessel checks may not be happening.

Co-Authored-By: Claude Opus 4.6

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## ROS RHEL GitHub label usage for executing a desired test suite

Select the appropriate GitHub label to control which ROS RHEL backend tests run for this PR (Labels can be added before or after commits are pushed):

**Note:** Changing a Label on a PR with an already-tested commit will not trigger a new test run

**Available ROS RHEL labels:**

- **test-backend-v1:** Run legacy backend tests only
- **test-backend-v2:** Run new backend tests only
- **test-backend-both:** Run both backend tests

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Prioritize Kessel-based access checks over legacy RBAC v1 in permission handling and add coverage to ensure the new ordering behaves as expected.

Bug Fixes:
- Ensure Kessel permission checks run and short-circuit before RBAC v1 when both mechanisms are enabled, preventing RBAC v1 errors for Kessel-managed orgs.

Tests:
- Add an API endpoint test verifying that Kessel is used and RBAC is not invoked when both flags are enabled.