### PR TITLE
Fix Content-Type override clobbering /metrics response

### DIFF
--- a/ros/lib/app.py
+++ b/ros/lib/app.py
@@ -43,6 +43,7 @@ def ensure_rbac():
 def add_headers(response):
     response.headers['Content-Security-Policy'] = "script-src 'self';"
     response.headers['Cache-Control'] = 'no-store'
-    response.headers['Content-Type'] = 'application/json; charset=UTF-8;'
+    if request.endpoint != 'prometheus_metrics':
+        response.headers['Content-Type'] = 'application/json; charset=UTF-8;'
     response.headers['Referrer-Policy'] = 'no-referrer'
     return response


### PR DESCRIPTION
## What
`add_headers()` in `ros/lib/app.py` unconditionally overwrites the `Content-Type` header on **every** response with `application/json; charset=UTF-8;`, including `/metrics` - clobbering the correct `text/plain` exposition-format header that `prometheus_flask_exporter` sets underneath.

## Why
Legacy Prometheus (2.x) parses the response body as classic exposition text regardless of Content-Type, so this went unnoticed - the body itself is valid Prometheus metrics text. Prometheus 3.x is stricter and rejects ambiguous Content-Type outright unless a `fallback_scrape_protocol` is configured, which caused App-SRE's newer Cluster Observability Operator Prometheus stack to report the `ros-backend-api` target as down (`up == 0`) while it worked fine under the legacy stack.

Verified live on crcp01ue1 by curling the pod directly with and without a Prometheus-3.x-style `Accept` header — the body was valid Prometheus text in both cases, only the `Content-Type` header was wrong (`application/json`), confirming this is unrelated to Accept-header negotiation and purely the `after_request` hook clobbering it.

## Fix
Skip the `Content-Type` override for the `prometheus_metrics` endpoint, mirroring the existing endpoint exclusion already used in `ensure_rbac()` right above it for the same reason (RBAC bypass for the scrape target).

Ref: [APPSRE-13041](https://redhat.atlassian.net/browse/APPSRE-13041)

[APPSRE-13041]: https://redhat.atlassian.net/browse/APPSRE-13041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Prevent the global response header hook from clobbering the Prometheus /metrics Content-Type, ensuring it remains text/plain as expected by Prometheus.