### PR TITLE
Fixes #RHINENG-29223 - gracefully handle the Kafka commits

### DIFF
--- a/ros/lib/config.py
+++ b/ros/lib/config.py
@@ -167,6 +167,11 @@ CACHE_TIMEOUT_FOR_DELETED_SYSTEM = int(
     os.getenv("CACHE_TIMEOUT_FOR_DELETED_SYSTEM", "86400"))
 CACHE_KEYWORD_FOR_DELETED_SYSTEM = '_del_'
 POLL_TIMEOUT_SECS = 1.0
+# Suggestions Engine can exceed the librdkafka default (300000ms) between poll()
+# calls while downloading archives and running PCP commands; raise to avoid MAXPOLL eviction.
+SUGGESTIONS_ENGINE_MAX_POLL_INTERVAL_MS = int(
+    os.getenv("SUGGESTIONS_ENGINE_MAX_POLL_INTERVAL_MS", "900000")
+)
 UNLEASH_ROS_V2_FLAG = 'ros.v2'
 
 

--- a/ros/lib/consume.py
+++ b/ros/lib/consume.py
@@ -2,11 +2,13 @@ from confluent_kafka import Consumer
 from ros.lib.config import kafka_auth_config
 
 
-def init_consumer(kafka_topic, GROUP_ID):
+def init_consumer(kafka_topic, GROUP_ID, max_poll_interval_ms=None):
     connection_object = {
         'group.id': GROUP_ID,
         'enable.auto.commit': False
     }
+    if max_poll_interval_ms is not None:
+        connection_object['max.poll.interval.ms'] = max_poll_interval_ms
     consumer = Consumer(kafka_auth_config(connection_object))
     # Subscribe to topic
     consumer.subscribe([kafka_topic])

--- a/ros/processor/notification_event_producer.py
+++ b/ros/processor/notification_event_producer.py
@@ -55,4 +55,4 @@ def new_suggestion_event(host, platform_metadata, system_previous_state, system_
         bytes_,
         on_delivery=lambda err, msg: delivery_report(err, msg, host.get('id'), request_id, NOTIFICATIONS_TOPIC)
     )
-    producer.poll()
+    producer.poll(0)

--- a/ros/processor/report_processor_event_producer.py
+++ b/ros/processor/report_processor_event_producer.py
@@ -417,7 +417,7 @@ def _send_event(producer, final_payload, host_id, request_id):
         key=host_id,
         on_delivery=lambda err, msg: delivery_report(err, msg, host_id, request_id, ROS_EVENTS_TOPIC)
     )
-    producer.poll()
+    producer.poll(0)
 
 
 def produce_report_processor_event(

--- a/ros/processor/suggestions_engine.py
+++ b/ros/processor/suggestions_engine.py
@@ -23,6 +23,7 @@ from ros.lib.config import (
     METRICS_PORT,
     INVENTORY_EVENTS_TOPIC,
     GROUP_ID_SUGGESTIONS_ENGINE,
+    SUGGESTIONS_ENGINE_MAX_POLL_INTERVAL_MS,
     UNLEASH_ROS_V2_FLAG
 )
 from ros.extensions import cache
@@ -44,7 +45,11 @@ logging = get_logger(__name__)
 
 class SuggestionsEngine:
     def __init__(self):
-        self.consumer = consume.init_consumer(INVENTORY_EVENTS_TOPIC, GROUP_ID_SUGGESTIONS_ENGINE)
+        self.consumer = consume.init_consumer(
+            INVENTORY_EVENTS_TOPIC,
+            GROUP_ID_SUGGESTIONS_ENGINE,
+            max_poll_interval_ms=SUGGESTIONS_ENGINE_MAX_POLL_INTERVAL_MS,
+        )
         self.producer = produce.init_producer()
         self.service = 'SUGGESTIONS_ENGINE'
         self.event = None
@@ -182,8 +187,7 @@ class SuggestionsEngine:
         logging.debug(f"{self.service} - {self.event} - Report downloading for system {host.get('id')}.")
 
         try:
-            response = requests.get(archive_URL, timeout=10)
-            self.consumer.commit()
+            response = requests.get(archive_URL, timeout=(10, 60))
 
             if response.status_code != HTTPStatus.OK:
                 logging.error(
@@ -202,6 +206,7 @@ class SuggestionsEngine:
                         yield extract_dir
         except Exception as error:
             logging.error(f"{self.service} - {self.event} - Error occurred during download and extraction: {error}")
+            yield None
 
     def handle_create_update(self, payload):
         self.event = "Update event" if payload.get('type') == 'updated' else "Create event"
@@ -227,6 +232,12 @@ class SuggestionsEngine:
                 host,
                 org_id=host.get('org_id')
         ) as ext_dir:
+            if ext_dir is None:
+                logging.error(
+                    f"{self.service} - {self.event} - "
+                    f"Failed to download/extract archive for system {host.get('id')}, skipping."
+                )
+                return
             extracted_dir = ext_dir.tmp_dir
             extracted_dir_root = self.find_root_directory(extracted_dir, "insights_archive.txt")
 
@@ -241,7 +252,6 @@ class SuggestionsEngine:
                 # Run only report_metadata rule (cloud_metadata is a condition, so it will be evaluated)
                 rules_runner = insights_run([report_metadata], root=extracted_dir_root)
 
-                self.consumer.commit()
                 produce_report_processor_event(
                     payload,
                     self.producer,
@@ -278,7 +288,6 @@ class SuggestionsEngine:
         logging.debug(
             f"{self.service} - {self.event} - Triggering an event for system {host.get('id')}, updated via API"
         )
-        self.consumer.commit()
         # API events don't have PCP data - only update System, no PerformanceProfile
         produce_report_processor_event(
             payload,
@@ -306,6 +315,8 @@ class SuggestionsEngine:
             self.handle_api_event(payload)
         elif event_type in ('created', 'updated'):
             self.handle_create_update(payload)
+
+        self.consumer.commit()
 
     def run(self):
         logging.info(f"{self.service} - Engine is running. Awaiting msgs.")

--- a/tests/test_suggestions_engine.py
+++ b/tests/test_suggestions_engine.py
@@ -54,7 +54,7 @@ class TestDownloadAndExtract(unittest.TestCase):
         ) as extract_dir:
             self.assertEqual(extract_dir.tmp_dir, "extracted_dir")
 
-        mock_get.assert_called_once_with("http://example.com/archive.tar.gz", timeout=10)
+        mock_get.assert_called_once_with("http://example.com/archive.tar.gz", timeout=(10, 60))
         mock_tempfile.return_value.__enter__.assert_called_once()
         mock_extract.assert_called_once()
 
@@ -73,7 +73,7 @@ class TestDownloadAndExtract(unittest.TestCase):
         ) as extract_dir:
             self.assertIsNone(extract_dir)
 
-        mock_get.assert_called_once_with("http://example.com/archive.tar.gz", timeout=10)
+        mock_get.assert_called_once_with("http://example.com/archive.tar.gz", timeout=(10, 60))
 
 
 class TestFindRootDirectory(unittest.TestCase):


### PR DESCRIPTION
## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## ROS RHEL GitHub label usage for executing a desired test suite

Select the appropriate GitHub label to control which ROS RHEL backend tests run for this PR (Labels can be added before or after commits are pushed):

**Note:** Changing a Label on a PR with an already-tested commit will not trigger a new test run

**Available ROS RHEL labels:**

- **test-backend-v1:** Run legacy backend tests only
- **test-backend-v2:** Run new backend tests only
- **test-backend-both:** Run both backend tests

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Handle Kafka consumer commits and producer polling more robustly in the suggestions engine and event producers.

Bug Fixes:
- Ensure Kafka consumer commits offsets once per message after successful handling instead of at intermediate stages.
- Avoid Kafka MAXPOLL interval evictions for the suggestions engine by allowing a configurable, higher max.poll.interval.ms.
- Prevent hangs or missed deliveries by explicitly polling and flushing Kafka producers with bounded timeouts.
- Handle download and extraction failures by yielding a sentinel value and skipping further processing when archives cannot be retrieved.

Enhancements:
- Increase HTTP download robustness by using separate connect and read timeouts for archive retrieval.
- Allow suggestions engine Kafka consumer configuration to accept an optional max.poll.interval.ms parameter.
- Tighten tests for suggestions engine download behavior to reflect the new timeout semantics.